### PR TITLE
feat: support adding and fetching recurrence with `rrule`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,7 @@ jobs:
           - "parser,serde_json"  # serde_json implies serde
           - "parser,chrono-tz"
           - "parser,time"
+          - "recurrence"
           - "chrono-tz"  # works without parser
           - "time"  # works without parser
           - "parser,serde_json,chrono-tz,time"  # all features combined

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ exclude = ["fixtures", ".github", ".gitignore", "*.json"]
 default = ["parser"]
 parser = ["dep:nom", "dep:nom-language"]
 strict-dates = []
+recurrence = ["dep:rrule"]
 
 [dependencies]
 serde = { version = "1.0.228", optional = true, features = ["derive"] }
@@ -27,7 +28,6 @@ serde_json = { version = "1.0.149", optional = true }
 iso8601 = "0.6"
 chrono-tz = { version = "0.10", optional = true }
 time = { version = "0.3.46", optional = true }
-rrule = "0.10.0"
 
 [dependencies.chrono]
 version = "0.4.43"
@@ -40,6 +40,10 @@ optional = true
 
 [dependencies.nom-language]
 version = "0.1"
+optional = true
+
+[dependencies.rrule]
+version = "0.10.0"
 optional = true
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies.uuid]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ default = ["parser"]
 parser = ["dep:nom", "dep:nom-language"]
 strict-dates = []
 chrono-tz = ["dep:chrono-tz"]
-recurrence = ["dep:rrule", "chrono-tz"]
+recurrence = ["dep:rrule", "chrono-tz", "dep:thiserror"]
 
 [dependencies]
 serde = { version = "1.0.228", optional = true, features = ["derive"] }
@@ -29,6 +29,7 @@ serde_json = { version = "1.0.149", optional = true }
 iso8601 = "0.6"
 chrono-tz = { version = "0.10", optional = true }
 time = { version = "0.3.46", optional = true }
+thiserror = { version = "2.0.18", optional = true }
 
 [dependencies.chrono]
 version = "0.4.43"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,8 @@ exclude = ["fixtures", ".github", ".gitignore", "*.json"]
 default = ["parser"]
 parser = ["dep:nom", "dep:nom-language"]
 strict-dates = []
-recurrence = ["dep:rrule", "dep:chrono-tz"]
+chrono-tz = ["dep:chrono-tz"]
+recurrence = ["dep:rrule", "chrono-tz"]
 
 [dependencies]
 serde = { version = "1.0.228", optional = true, features = ["derive"] }
@@ -68,7 +69,7 @@ required-features = ["parser"]
 [[example]]
 name = "readme_parse"
 path = "examples/readme-parse.rs"
-required-features = ["parser"]
+required-features = ["parser", "chrono-tz"]
 
 [[example]]
 name = "parse_advanced"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ version = "0.1"
 optional = true
 
 [dependencies.rrule]
-version = "0.10.0"
+version = "0.13"
 optional = true
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies.uuid]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,3 +99,13 @@ required-features = ["parser"]
 name = "timezone"
 path = "examples/timezone.rs"
 required-features = ["chrono-tz"]
+
+[[example]]
+name = "recurrence"
+path = "examples/recurrence.rs"
+required-features = ["recurrence"]
+
+[[example]]
+name = "recurrence_parse"
+path = "examples/recurrence_parse.rs"
+required-features = ["recurrence"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ serde_json = { version = "1.0.149", optional = true }
 iso8601 = "0.6"
 chrono-tz = { version = "0.10", optional = true }
 time = { version = "0.3.46", optional = true }
+rrule = "0.10.0"
 
 [dependencies.chrono]
 version = "0.4.43"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ exclude = ["fixtures", ".github", ".gitignore", "*.json"]
 default = ["parser"]
 parser = ["dep:nom", "dep:nom-language"]
 strict-dates = []
-recurrence = ["dep:rrule"]
+recurrence = ["dep:rrule", "dep:chrono-tz"]
 
 [dependencies]
 serde = { version = "1.0.228", optional = true, features = ["derive"] }
@@ -43,7 +43,7 @@ version = "0.1"
 optional = true
 
 [dependencies.rrule]
-version = "0.13"
+version = "0.14"
 optional = true
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies.uuid]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -109,4 +109,4 @@ required-features = ["recurrence"]
 [[example]]
 name = "recurrence_parse"
 path = "examples/recurrence_parse.rs"
-required-features = ["recurrence"]
+required-features = ["recurrence", "parser"]

--- a/examples/recurrence.rs
+++ b/examples/recurrence.rs
@@ -1,0 +1,34 @@
+#![cfg(feature = "recurrence")]
+use chrono::*;
+use icalendar::*;
+
+// maximum number of events accepted
+const RECURRENCE_LIMIT: u16 = u16::MAX;
+
+fn main() {
+    let dt_start = rrule::Tz::Europe__London
+        .with_ymd_and_hms(2025, 3, 17, 0, 0, 0)
+        .unwrap();
+
+    let my_event = Event::new()
+        .all_day(NaiveDate::from_ymd_opt(2025, 3, 17).unwrap())
+        .summary("weekly event")
+        .description("this event happens every Monday for four weeks")
+        .recurrence(
+            rrule::RRule::default()
+                .count(4)
+                .freq(rrule::Frequency::Weekly)
+                .by_weekday(vec![rrule::NWeekday::Every(rrule::Weekday::Mon)])
+                .build(dt_start)
+                .unwrap(),
+        )
+        .done();
+
+    let all_occurences = my_event
+        .get_recurrence()
+        .unwrap()
+        .all(RECURRENCE_LIMIT)
+        .dates;
+
+    println!("{:#?}", all_occurences);
+}

--- a/examples/recurrence.rs
+++ b/examples/recurrence.rs
@@ -27,6 +27,7 @@ fn main() {
     let all_occurences = my_event
         .get_recurrence()
         .unwrap()
+        .unwrap()
         .all(RECURRENCE_LIMIT)
         .dates;
 

--- a/examples/recurrence.rs
+++ b/examples/recurrence.rs
@@ -1,15 +1,12 @@
 #![cfg(feature = "recurrence")]
-use chrono::*;
+use chrono::NaiveDate;
 use icalendar::*;
 
 // maximum number of events accepted
 const RECURRENCE_LIMIT: u16 = u16::MAX;
 
 fn main() {
-    let dt_start = rrule::Tz::Europe__London
-        .with_ymd_and_hms(2025, 3, 17, 0, 0, 0)
-        .unwrap();
-
+    // Note: .all_day() sets DTSTART; .recurrence() derives the start time from it automatically.
     let my_event = Event::new()
         .all_day(NaiveDate::from_ymd_opt(2025, 3, 17).unwrap())
         .summary("weekly event")
@@ -18,10 +15,9 @@ fn main() {
             rrule::RRule::default()
                 .count(4)
                 .freq(rrule::Frequency::Weekly)
-                .by_weekday(vec![rrule::NWeekday::Every(rrule::Weekday::Mon)])
-                .build(dt_start)
-                .unwrap(),
+                .by_weekday(vec![rrule::NWeekday::Every(rrule::Weekday::Mon)]),
         )
+        .expect("DTSTART must be set and the rule must be valid")
         .done();
 
     let all_occurences = my_event

--- a/examples/recurrence.rs
+++ b/examples/recurrence.rs
@@ -12,10 +12,10 @@ fn main() {
         .summary("weekly event")
         .description("this event happens every Monday for four weeks")
         .recurrence(
-            rrule::RRule::default()
+            RRule::default()
                 .count(4)
-                .freq(rrule::Frequency::Weekly)
-                .by_weekday(vec![rrule::NWeekday::Every(rrule::Weekday::Mon)]),
+                .freq(Frequency::Weekly)
+                .by_weekday(vec![NWeekday::Every(Weekday::Mon)]),
         )
         .expect("DTSTART must be set and the rule must be valid")
         .done();

--- a/examples/recurrence.rs
+++ b/examples/recurrence.rs
@@ -20,12 +20,11 @@ fn main() {
         .expect("DTSTART must be set and the rule must be valid")
         .done();
 
-    let all_occurences = my_event
+    let all_occurrences = my_event
         .get_recurrence()
-        .unwrap()
-        .unwrap()
+        .expect("event should have a recurrence rule")
         .all(RECURRENCE_LIMIT)
         .dates;
 
-    println!("{:#?}", all_occurences);
+    println!("{:#?}", all_occurrences);
 }

--- a/examples/recurrence_parse.rs
+++ b/examples/recurrence_parse.rs
@@ -15,9 +15,7 @@ fn main() {
         if let CalendarComponent::Event(event) = component {
             println!("Event: {}", event.get_summary().unwrap());
             if let Some(rrules) = event.get_recurrence() {
-                let datetimes: Vec<DateTime<rrule::Tz>> = rrules
-                    .all(RECURRENCE_LIMIT)
-                    .dates;
+                let datetimes: Vec<DateTime<rrule::Tz>> = rrules.all(RECURRENCE_LIMIT).dates;
 
                 println!("Repeating on the following dates (showing first 10): ");
                 println!("{:#?}", &datetimes[..10]);

--- a/examples/recurrence_parse.rs
+++ b/examples/recurrence_parse.rs
@@ -1,0 +1,27 @@
+#![cfg(feature = "recurrence")]
+use chrono::*;
+use icalendar::*;
+use std::fs;
+
+// maximum number of events accepted
+const RECURRENCE_LIMIT: u16 = u16::MAX;
+
+fn main() {
+    let contents = fs::read_to_string("fixtures/icalendar-rb/recurrence.ics").unwrap();
+
+    let parsed_calendar: Calendar = contents.parse().unwrap();
+
+    for component in &parsed_calendar.components {
+        if let CalendarComponent::Event(event) = component {
+            println!("Event: {}", event.get_summary().unwrap());
+            if let Some(rrules) = event.get_recurrence() {
+                let datetimes: Vec<DateTime<rrule::Tz>> = rrules
+                    .all(RECURRENCE_LIMIT)
+                    .dates;
+
+                println!("Repeating on the following dates (showing first 10): ");
+                println!("{:#?}", &datetimes[..10]);
+            }
+        }
+    }
+}

--- a/examples/recurrence_parse.rs
+++ b/examples/recurrence_parse.rs
@@ -14,7 +14,7 @@ fn main() {
     for component in &parsed_calendar.components {
         if let CalendarComponent::Event(event) = component {
             println!("Event: {}", event.get_summary().unwrap());
-            if let Some(rrules) = event.get_recurrence() {
+            if let Some(Ok(rrules)) = event.get_recurrence() {
                 let datetimes: Vec<DateTime<rrule::Tz>> = rrules.all(RECURRENCE_LIMIT).dates;
 
                 println!("Repeating on the following dates (showing first 10): ");

--- a/examples/recurrence_parse.rs
+++ b/examples/recurrence_parse.rs
@@ -14,7 +14,7 @@ fn main() {
     for component in &parsed_calendar.components {
         if let CalendarComponent::Event(event) = component {
             println!("Event: {}", event.get_summary().unwrap());
-            if let Some(Ok(rrules)) = event.get_recurrence() {
+            if let Some(rrules) = event.get_recurrence() {
                 let datetimes: Vec<DateTime<Tz>> = rrules.all(RECURRENCE_LIMIT).dates;
 
                 println!("Repeating on the following dates (showing first 10): ");

--- a/examples/recurrence_parse.rs
+++ b/examples/recurrence_parse.rs
@@ -15,7 +15,7 @@ fn main() {
         if let CalendarComponent::Event(event) = component {
             println!("Event: {}", event.get_summary().unwrap());
             if let Some(Ok(rrules)) = event.get_recurrence() {
-                let datetimes: Vec<DateTime<rrule::Tz>> = rrules.all(RECURRENCE_LIMIT).dates;
+                let datetimes: Vec<DateTime<Tz>> = rrules.all(RECURRENCE_LIMIT).dates;
 
                 println!("Repeating on the following dates (showing first 10): ");
                 println!("{:#?}", &datetimes[..10]);

--- a/src/components.rs
+++ b/src/components.rs
@@ -514,10 +514,26 @@ pub trait EventLike: Component {
 
     /// Get recurrence rules.
     ///
+    /// Returns `None` if no `RRULE` property is present on this component, or if the
+    /// rule could not be parsed. Use [`try_recurrence`](EventLike::try_recurrence) if
+    /// you need to distinguish between the two cases or want to inspect the parse error.
+    #[cfg(feature = "recurrence")]
+    fn get_recurrence(&self) -> Option<RRuleSet> {
+        self.try_recurrence()?.ok()
+    }
+
+    /// Get recurrence rules, returning a parse error if the `RRULE` property is present
+    /// but invalid.
+    ///
     /// Returns `None` if no `RRULE` property is present on this component.
     /// Returns `Some(Err(_))` if an `RRULE` is present but could not be parsed.
+    /// Returns `Some(Ok(_))` if the rule was parsed successfully.
+    ///
+    /// Prefer [`get_recurrence`](EventLike::get_recurrence) for the common case where you
+    /// trust the data source. Use this variant when working with parsed `.ics` input that
+    /// you did not produce yourself and want to surface errors to the caller.
     #[cfg(feature = "recurrence")]
-    fn get_recurrence(&self) -> Option<Result<RRuleSet, RRuleError>> {
+    fn try_recurrence(&self) -> Option<Result<RRuleSet, RRuleError>> {
         let dt_start_prop = self.properties().get("DTSTART")?;
         // rrule's parser only understands DTSTART with an optional TZID parameter.
         // Other parameters like VALUE=DATE must be omitted, otherwise rrule misinterprets them.
@@ -827,7 +843,9 @@ mod tests {
             .unwrap()
             .done();
 
-        let output = event.get_recurrence().unwrap().unwrap();
+        let output = event
+            .get_recurrence()
+            .expect("event should have a recurrence rule");
 
         let output_rrules = output.get_rrule();
 
@@ -878,7 +896,9 @@ mod test_recurrence_tzid {
             .unwrap()
             .done();
 
-        let rrule_set_out = event.get_recurrence().unwrap().unwrap();
+        let rrule_set_out = event
+            .get_recurrence()
+            .expect("event should have a recurrence rule");
         let dates = rrule_set_out.all(10).dates;
 
         assert_eq!(dates.len(), 3);
@@ -917,7 +937,11 @@ mod test_recurrence_tzid {
             .unwrap()
             .done();
 
-        let original_dates = event.get_recurrence().unwrap().unwrap().all(10).dates;
+        let original_dates = event
+            .get_recurrence()
+            .expect("event should have a recurrence rule")
+            .all(10)
+            .dates;
 
         // Serialize → parse back
         let mut calendar = Calendar::new();
@@ -939,8 +963,7 @@ mod test_recurrence_tzid {
 
         let reparsed_dates = reparsed_event
             .get_recurrence()
-            .unwrap()
-            .unwrap()
+            .expect("reparsed event should have a recurrence rule")
             .all(10)
             .dates;
 
@@ -962,7 +985,11 @@ mod test_recurrence_tzid {
             .unwrap()
             .done();
 
-        let dates = event.get_recurrence().unwrap().unwrap().all(10).dates;
+        let dates = event
+            .get_recurrence()
+            .expect("event should have a recurrence rule")
+            .all(10)
+            .dates;
         assert_eq!(dates.len(), 4);
         for dt in &dates {
             assert_eq!(dt.timezone(), Tz::UTC);
@@ -983,23 +1010,25 @@ mod test_recurrence_errors {
             .done();
 
         assert!(event.get_recurrence().is_none());
+        assert!(event.try_recurrence().is_none());
     }
 
-    /// An event with a valid RRULE should return Some(Ok(_)).
+    /// An event with a valid RRULE should return Some(_) / Some(Ok(_)).
     #[test]
-    fn valid_rrule_returns_some_ok() {
+    fn valid_rrule_returns_some() {
         let event = Event::new()
             .starts(Utc.with_ymd_and_hms(2025, 1, 1, 9, 0, 0).unwrap())
             .recurrence(RRule::default().count(3).freq(Frequency::Daily))
             .unwrap()
             .done();
 
-        assert!(matches!(event.get_recurrence(), Some(Ok(_))));
+        assert!(event.get_recurrence().is_some());
+        assert!(matches!(event.try_recurrence(), Some(Ok(_))));
     }
 
-    /// An event with a syntactically invalid RRULE value should return Some(Err(_)).
+    /// An event with a syntactically invalid RRULE value should return None / Some(Err(_)).
     #[test]
-    fn invalid_rrule_returns_some_err() {
+    fn invalid_rrule_returns_none_and_some_err() {
         use crate::Component;
 
         let event = Event::new()
@@ -1007,6 +1036,7 @@ mod test_recurrence_errors {
             .add_property("RRULE", "THIS IS NOT VALID")
             .done();
 
-        assert!(matches!(event.get_recurrence(), Some(Err(_))));
+        assert!(event.get_recurrence().is_none());
+        assert!(matches!(event.try_recurrence(), Some(Err(_))));
     }
 }

--- a/src/components.rs
+++ b/src/components.rs
@@ -1,6 +1,6 @@
 use chrono::{DateTime, NaiveDate, Utc};
 #[cfg(feature = "recurrence")]
-use rrule::{RRule, RRuleError, RRuleSet, Unvalidated};
+use rrule::{RRuleError, RRuleSet};
 use uuid::Uuid;
 
 use std::{collections::BTreeMap, fmt, mem};
@@ -447,7 +447,7 @@ pub trait EventLike: Component {
     /// Returns `Err` if `DTSTART` is missing, the timezone name is unrecognised, or
     /// the rule fails rrule's own validation.
     #[cfg(feature = "recurrence")]
-    fn recurrence(&mut self, rrule: RRule<Unvalidated>) -> Result<&mut Self, RRuleError> {
+    fn recurrence(&mut self, rrule: crate::UnvalidatedRRule) -> Result<&mut Self, RRuleError> {
         use chrono::TimeZone as _;
         use date_time::{CalendarDateTime, DatePerhapsTime};
 
@@ -862,10 +862,10 @@ mod tests {
 #[cfg(all(test, feature = "recurrence", feature = "parser"))]
 mod test_recurrence_tzid {
     use crate::{CalendarComponent, Event, EventLike};
-    use crate::{Frequency, RRule, Tz, Unvalidated};
+    use crate::{Frequency, RRule, Tz, UnvalidatedRRule};
 
     /// Builds an unbuilt weekly `RRule` for UTC tests.
-    fn weekly_utc_rrule() -> RRule<Unvalidated> {
+    fn weekly_utc_rrule() -> UnvalidatedRRule {
         RRule::default().count(4).freq(Frequency::Weekly)
     }
 

--- a/src/components.rs
+++ b/src/components.rs
@@ -1,6 +1,6 @@
 use chrono::{DateTime, NaiveDate, Utc};
 #[cfg(feature = "recurrence")]
-use rrule::{RRuleError, RRuleSet};
+use rrule::{RRule, RRuleError, RRuleSet, Unvalidated};
 use uuid::Uuid;
 
 use std::{collections::BTreeMap, fmt, mem};
@@ -439,10 +439,52 @@ pub trait EventLike: Component {
         self.property_value("LOCATION")
     }
 
-    /// Set recurrence rules
+    /// Set recurrence rules from an [`rrule::RRule`].
+    ///
+    /// The `DTSTART` of this component is used as the start date for the recurrence rule,
+    /// so `.starts()` or `.all_day()` must be called before `.recurrence()`.
+    ///
+    /// Returns `Err` if `DTSTART` is missing, the timezone name is unrecognised, or
+    /// the rule fails rrule's own validation.
     #[cfg(feature = "recurrence")]
-    fn recurrence(&mut self, rruleset: RRuleSet) -> &mut Self {
-        let rrules = rruleset
+    fn recurrence(&mut self, rrule: RRule<Unvalidated>) -> Result<&mut Self, RRuleError> {
+        use chrono::TimeZone as _;
+        use date_time::{CalendarDateTime, DatePerhapsTime};
+
+        // Derive dt_start from whatever DTSTART is already on the component.
+        let dt_start_prop = self.properties().get("DTSTART").ok_or_else(|| {
+            RRuleError::new_iter_err("DTSTART must be set before calling recurrence()")
+        })?;
+
+        let dt_start: DateTime<rrule::Tz> = match DatePerhapsTime::from_property(dt_start_prop) {
+            Some(DatePerhapsTime::DateTime(CalendarDateTime::Utc(utc))) => {
+                rrule::Tz::UTC.from_utc_datetime(&utc.naive_utc())
+            }
+            Some(DatePerhapsTime::DateTime(CalendarDateTime::WithTimezone { date_time, tzid })) => {
+                let tz: rrule::Tz = tzid
+                    .parse::<chrono_tz::Tz>()
+                    .map_err(|_| RRuleError::new_iter_err("unrecognised TZID in DTSTART"))?
+                    .into();
+                tz.from_local_datetime(&date_time).single().ok_or_else(|| {
+                    RRuleError::new_iter_err("ambiguous or invalid local datetime for DTSTART TZID")
+                })?
+            }
+            Some(DatePerhapsTime::DateTime(CalendarDateTime::Floating(naive))) => {
+                // Floating datetimes have no timezone — use UTC as a best-effort interpretation.
+                rrule::Tz::UTC.from_utc_datetime(&naive)
+            }
+            Some(DatePerhapsTime::Date(naive_date)) => {
+                // All-day events: treat as midnight UTC.
+                rrule::Tz::UTC.from_utc_datetime(&naive_date.and_hms_opt(0, 0, 0).unwrap())
+            }
+            None => {
+                return Err(RRuleError::new_iter_err("could not parse DTSTART property"));
+            }
+        };
+
+        let rruleset = rrule.build(dt_start)?;
+
+        let rrule_str = rruleset
             .get_rrule()
             .iter()
             .map(ToString::to_string)
@@ -463,9 +505,11 @@ pub trait EventLike: Component {
             .collect::<Vec<_>>()
             .join(",");
 
-        self.add_property("RRULE", rrules)
+        self.add_property("RRULE", rrule_str)
             .add_multi_property("RDATE", &rdates)
-            .add_multi_property("EXDATE", &exdates)
+            .add_multi_property("EXDATE", &exdates);
+
+        Ok(self)
     }
 
     /// Get recurrence rules.
@@ -764,27 +808,23 @@ mod tests {
     #[test]
     #[cfg(feature = "recurrence")]
     fn get_recurrence() {
-        use crate::rrule::{Frequency, NWeekday, RRule, Tz, Weekday};
+        use crate::rrule::{Frequency, NWeekday, RRule, Weekday};
 
         let naive_date = NaiveDate::from_ymd_opt(2001, 3, 13).unwrap();
-        let dt_start = Tz::UTC.with_ymd_and_hms(2001, 3, 13, 0, 0, 0).unwrap();
-        let ex_date = Tz::UTC.with_ymd_and_hms(2001, 3, 14, 0, 0, 0).unwrap();
 
-        let rrule_set = RRule::default()
+        let rrule = RRule::default()
             .count(4)
             .freq(Frequency::Weekly)
             .by_weekday(vec![
                 NWeekday::Every(Weekday::Tue),
                 NWeekday::Every(Weekday::Wed),
-            ])
-            .build(dt_start)
-            .unwrap()
-            .set_exdates(vec![ex_date]);
+            ]);
 
         let event = Event::new()
             .starts(naive_date)
             .ends(naive_date)
-            .recurrence(rrule_set)
+            .recurrence(rrule)
+            .unwrap()
             .done();
 
         let output = event.get_recurrence().unwrap().unwrap();
@@ -798,48 +838,33 @@ mod tests {
             output_rrules.first().unwrap().get_by_weekday(),
             [NWeekday::Every(Weekday::Tue), NWeekday::Every(Weekday::Wed)]
         );
-
-        let output_exdates = output.get_exdate();
-
-        assert_eq!(output_exdates, &vec![ex_date]);
     }
 }
 
 #[cfg(all(test, feature = "recurrence", feature = "parser"))]
 mod test_recurrence_tzid {
-    use chrono::TimeZone as _;
-    use crate::rrule::{Frequency, RRule, RRuleSet, Tz};
+    use crate::rrule::{Frequency, RRule, Tz, Unvalidated};
     use crate::{CalendarComponent, Event, EventLike};
+    use crate::{Frequency, RRule, Tz, Unvalidated};
 
-    /// Builds an RRuleSet with a UTC DTSTART and a weekly rule, used across several tests.
-    fn weekly_utc_rrule_set() -> RRuleSet {
-        let dt_start = Tz::UTC.with_ymd_and_hms(2025, 3, 17, 9, 0, 0).unwrap();
-        RRule::default()
-            .count(4)
-            .freq(Frequency::Weekly)
-            .build(dt_start)
-            .unwrap()
+    /// Builds an unbuilt weekly `RRule` for UTC tests.
+    fn weekly_utc_rrule() -> RRule<Unvalidated> {
+        RRule::default().count(4).freq(Frequency::Weekly)
     }
 
     /// A `DTSTART;TZID=...` event should produce occurrences in the named timezone,
     /// not in UTC or the local machine timezone.
     #[test]
     fn tzid_dtstart_preserves_timezone() {
-        use chrono::NaiveDate;
         use crate::components::date_time::CalendarDateTime;
         use crate::rrule::NWeekday;
         use crate::rrule::Weekday;
+        use chrono::NaiveDate;
 
-        let dt_start_rrule = Tz::Europe__Berlin
-            .with_ymd_and_hms(2025, 6, 2, 10, 0, 0)
-            .unwrap();
-
-        let rrule_set = RRule::default()
+        let rrule = RRule::default()
             .count(3)
             .freq(Frequency::Weekly)
-            .by_weekday(vec![NWeekday::Every(Weekday::Mon)])
-            .build(dt_start_rrule)
-            .unwrap();
+            .by_weekday(vec![NWeekday::Every(Weekday::Mon)]);
 
         let dt_start_ical = CalendarDateTime::WithTimezone {
             date_time: NaiveDate::from_ymd_opt(2025, 6, 2)
@@ -851,7 +876,8 @@ mod test_recurrence_tzid {
 
         let event = Event::new()
             .starts(dt_start_ical)
-            .recurrence(rrule_set)
+            .recurrence(rrule)
+            .unwrap()
             .done();
 
         let rrule_set_out = event.get_recurrence().unwrap().unwrap();
@@ -869,22 +895,16 @@ mod test_recurrence_tzid {
     /// same occurrences as the original (round-trip correctness).
     #[test]
     fn tzid_dtstart_round_trips_through_serialization() {
-        use chrono::NaiveDate;
+        use crate::Calendar;
         use crate::components::date_time::CalendarDateTime;
         use crate::rrule::NWeekday;
         use crate::rrule::Weekday;
-        use crate::Calendar;
+        use chrono::NaiveDate;
 
-        let dt_start_rrule = Tz::Europe__Berlin
-            .with_ymd_and_hms(2025, 6, 2, 10, 0, 0)
-            .unwrap();
-
-        let rrule_set = RRule::default()
+        let rrule = RRule::default()
             .count(3)
             .freq(Frequency::Weekly)
-            .by_weekday(vec![NWeekday::Every(Weekday::Mon)])
-            .build(dt_start_rrule)
-            .unwrap();
+            .by_weekday(vec![NWeekday::Every(Weekday::Mon)]);
 
         let dt_start_ical = CalendarDateTime::WithTimezone {
             date_time: NaiveDate::from_ymd_opt(2025, 6, 2)
@@ -896,7 +916,8 @@ mod test_recurrence_tzid {
 
         let event = Event::new()
             .starts(dt_start_ical)
-            .recurrence(rrule_set)
+            .recurrence(rrule)
+            .unwrap()
             .done();
 
         let original_dates = event.get_recurrence().unwrap().unwrap().all(10).dates;
@@ -919,7 +940,12 @@ mod test_recurrence_tzid {
             })
             .unwrap();
 
-        let reparsed_dates = reparsed_event.get_recurrence().unwrap().unwrap().all(10).dates;
+        let reparsed_dates = reparsed_event
+            .get_recurrence()
+            .unwrap()
+            .unwrap()
+            .all(10)
+            .dates;
 
         assert_eq!(original_dates, reparsed_dates);
         assert_eq!(reparsed_dates.len(), 3);
@@ -935,7 +961,8 @@ mod test_recurrence_tzid {
 
         let event = Event::new()
             .starts(CalendarDateTime::Utc(utc_dt))
-            .recurrence(weekly_utc_rrule_set())
+            .recurrence(weekly_utc_rrule())
+            .unwrap()
             .done();
 
         let dates = event.get_recurrence().unwrap().unwrap().all(10).dates;
@@ -948,7 +975,7 @@ mod test_recurrence_tzid {
 
 #[cfg(all(test, feature = "recurrence"))]
 mod test_recurrence_errors {
-    use crate::rrule::{Frequency, RRule, Tz};
+    use crate::rrule::{Frequency, RRule};
     use crate::{Event, EventLike};
     use chrono::{TimeZone as _, Utc};
     use crate::{Frequency, RRule};
@@ -967,16 +994,10 @@ mod test_recurrence_errors {
     /// An event with a valid RRULE should return Some(Ok(_)).
     #[test]
     fn valid_rrule_returns_some_ok() {
-        let dt_start = Tz::UTC.with_ymd_and_hms(2025, 1, 1, 9, 0, 0).unwrap();
-        let rrule_set = RRule::default()
-            .count(3)
-            .freq(Frequency::Daily)
-            .build(dt_start)
-            .unwrap();
-
         let event = Event::new()
             .starts(Utc.with_ymd_and_hms(2025, 1, 1, 9, 0, 0).unwrap())
-            .recurrence(rrule_set)
+            .recurrence(RRule::default().count(3).freq(Frequency::Daily))
+            .unwrap()
             .done();
 
         assert!(matches!(event.get_recurrence(), Some(Ok(_))));

--- a/src/components.rs
+++ b/src/components.rs
@@ -1,6 +1,8 @@
+#[cfg(feature = "recurrence")]
+use crate::recurrence::RecurrenceError;
 use chrono::{DateTime, NaiveDate, Utc};
 #[cfg(feature = "recurrence")]
-use rrule::{RRuleError, RRuleSet};
+use rrule::RRuleSet;
 use uuid::Uuid;
 
 use std::{collections::BTreeMap, fmt, mem};
@@ -447,14 +449,15 @@ pub trait EventLike: Component {
     /// Returns `Err` if `DTSTART` is missing, the timezone name is unrecognised, or
     /// the rule fails rrule's own validation.
     #[cfg(feature = "recurrence")]
-    fn recurrence(&mut self, rrule: crate::UnvalidatedRRule) -> Result<&mut Self, RRuleError> {
+    fn recurrence(&mut self, rrule: crate::UnvalidatedRRule) -> Result<&mut Self, RecurrenceError> {
         use chrono::TimeZone as _;
         use date_time::{CalendarDateTime, DatePerhapsTime};
 
         // Derive dt_start from whatever DTSTART is already on the component.
-        let dt_start_prop = self.properties().get("DTSTART").ok_or_else(|| {
-            RRuleError::new_iter_err("DTSTART must be set before calling recurrence()")
-        })?;
+        let dt_start_prop = self
+            .properties()
+            .get("DTSTART")
+            .ok_or(RecurrenceError::MissingDtStart)?;
 
         let dt_start: DateTime<rrule::Tz> = match DatePerhapsTime::from_property(dt_start_prop) {
             Some(DatePerhapsTime::DateTime(CalendarDateTime::Utc(utc))) => {
@@ -463,11 +466,11 @@ pub trait EventLike: Component {
             Some(DatePerhapsTime::DateTime(CalendarDateTime::WithTimezone { date_time, tzid })) => {
                 let tz: rrule::Tz = tzid
                     .parse::<chrono_tz::Tz>()
-                    .map_err(|_| RRuleError::new_iter_err("unrecognised TZID in DTSTART"))?
+                    .map_err(|_| RecurrenceError::InvalidTimezone(tzid.clone()))?
                     .into();
-                tz.from_local_datetime(&date_time).single().ok_or_else(|| {
-                    RRuleError::new_iter_err("ambiguous or invalid local datetime for DTSTART TZID")
-                })?
+                tz.from_local_datetime(&date_time)
+                    .single()
+                    .ok_or(RecurrenceError::AmbiguousDateTime)?
             }
             Some(DatePerhapsTime::DateTime(CalendarDateTime::Floating(naive))) => {
                 // Floating datetimes have no timezone — use UTC as a best-effort interpretation.
@@ -478,7 +481,7 @@ pub trait EventLike: Component {
                 rrule::Tz::UTC.from_utc_datetime(&naive_date.and_hms_opt(0, 0, 0).unwrap())
             }
             None => {
-                return Err(RRuleError::new_iter_err("could not parse DTSTART property"));
+                return Err(RecurrenceError::InvalidDtStart);
             }
         };
 
@@ -533,7 +536,7 @@ pub trait EventLike: Component {
     /// trust the data source. Use this variant when working with parsed `.ics` input that
     /// you did not produce yourself and want to surface errors to the caller.
     #[cfg(feature = "recurrence")]
-    fn try_recurrence(&self) -> Option<Result<RRuleSet, RRuleError>> {
+    fn try_recurrence(&self) -> Option<Result<RRuleSet, RecurrenceError>> {
         let dt_start_prop = self.properties().get("DTSTART")?;
         // rrule's parser only understands DTSTART with an optional TZID parameter.
         // Other parameters like VALUE=DATE must be omitted, otherwise rrule misinterprets them.
@@ -569,7 +572,7 @@ pub trait EventLike: Component {
         }
 
         let rrules = format!("{dt_start_str}\nRRULE:{rrule_str}{rdates_str}{exdates_str}");
-        Some(rrules.parse::<RRuleSet>())
+        Some(rrules.parse::<RRuleSet>().map_err(RecurrenceError::Rule))
     }
 
     /// Set the ALARM for this event
@@ -999,7 +1002,7 @@ mod test_recurrence_tzid {
 
 #[cfg(all(test, feature = "recurrence"))]
 mod test_recurrence_errors {
-    use crate::{Event, EventLike as _, Frequency, RRule};
+    use crate::{Event, EventLike as _, Frequency, RRule, RecurrenceError};
     use chrono::{TimeZone as _, Utc};
 
     /// An event with no RRULE property should return None.
@@ -1037,6 +1040,41 @@ mod test_recurrence_errors {
             .done();
 
         assert!(event.get_recurrence().is_none());
-        assert!(matches!(event.try_recurrence(), Some(Err(_))));
+        assert!(matches!(
+            event.try_recurrence(),
+            Some(Err(RecurrenceError::Rule(_)))
+        ));
+    }
+
+    /// Calling `recurrence()` before setting DTSTART should return `MissingDtStart`.
+    #[test]
+    fn missing_dtstart_returns_error() {
+        let mut event = Event::new();
+        let result = event.recurrence(RRule::default().freq(Frequency::Daily));
+        assert!(matches!(result, Err(RecurrenceError::MissingDtStart)));
+    }
+
+    /// An unrecognised TZID in DTSTART should return `InvalidTimezone`.
+    #[test]
+    fn invalid_timezone_returns_error() {
+        use crate::components::date_time::CalendarDateTime;
+        use chrono::NaiveDate;
+
+        let dt_start = CalendarDateTime::WithTimezone {
+            date_time: NaiveDate::from_ymd_opt(2025, 1, 1)
+                .unwrap()
+                .and_hms_opt(9, 0, 0)
+                .unwrap(),
+            tzid: "Not/ATimezone".to_string(),
+        };
+
+        let mut event = Event::new();
+        event.starts(dt_start);
+        let result = event.recurrence(RRule::default().freq(Frequency::Daily));
+
+        assert!(matches!(
+            result,
+            Err(RecurrenceError::InvalidTimezone(tz)) if tz == "Not/ATimezone"
+        ));
     }
 }

--- a/src/components.rs
+++ b/src/components.rs
@@ -1,4 +1,5 @@
 use chrono::{DateTime, NaiveDate, Utc};
+use rrule::RRuleSet;
 use uuid::Uuid;
 
 use std::{collections::BTreeMap, fmt, mem};
@@ -435,6 +436,27 @@ pub trait EventLike: Component {
     /// Gets the location
     fn get_location(&self) -> Option<&str> {
         self.property_value("LOCATION")
+    }
+
+    /// Set recurrence rules
+    fn recurrence(&mut self, rruleset: RRuleSet) -> &mut Self {
+        let properties = rruleset
+            .get_rrule()
+            .iter()
+            .map(ToString::to_string)
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        self.add_property("RRULE", properties)
+    }
+
+    /// Get recurrence rules
+    fn get_recurrence(&self) -> Option<RRuleSet> {
+        let dt_start_str = self.property_value("DTSTART")?;
+        let rrule_str = self.property_value("RRULE")?;
+        let rrules = format!("DTSTART:{}\nRRULE:{}", dt_start_str, rrule_str);
+
+        rrules.parse::<RRuleSet>().ok()
     }
 
     /// Set the ALARM for this event

--- a/src/components.rs
+++ b/src/components.rs
@@ -808,7 +808,7 @@ mod tests {
     #[test]
     #[cfg(feature = "recurrence")]
     fn get_recurrence() {
-        use crate::rrule::{Frequency, NWeekday, RRule, Weekday};
+        use crate::{Frequency, NWeekday, RRule, Weekday};
 
         let naive_date = NaiveDate::from_ymd_opt(2001, 3, 13).unwrap();
 
@@ -843,7 +843,6 @@ mod tests {
 
 #[cfg(all(test, feature = "recurrence", feature = "parser"))]
 mod test_recurrence_tzid {
-    use crate::rrule::{Frequency, RRule, Tz, Unvalidated};
     use crate::{CalendarComponent, Event, EventLike};
     use crate::{Frequency, RRule, Tz, Unvalidated};
 
@@ -857,8 +856,7 @@ mod test_recurrence_tzid {
     #[test]
     fn tzid_dtstart_preserves_timezone() {
         use crate::components::date_time::CalendarDateTime;
-        use crate::rrule::NWeekday;
-        use crate::rrule::Weekday;
+        use crate::{NWeekday, Weekday};
         use chrono::NaiveDate;
 
         let rrule = RRule::default()
@@ -897,8 +895,7 @@ mod test_recurrence_tzid {
     fn tzid_dtstart_round_trips_through_serialization() {
         use crate::Calendar;
         use crate::components::date_time::CalendarDateTime;
-        use crate::rrule::NWeekday;
-        use crate::rrule::Weekday;
+        use crate::{NWeekday, Weekday};
         use chrono::NaiveDate;
 
         let rrule = RRule::default()
@@ -975,10 +972,7 @@ mod test_recurrence_tzid {
 
 #[cfg(all(test, feature = "recurrence"))]
 mod test_recurrence_errors {
-    use crate::rrule::{Frequency, RRule};
-    use crate::{Event, EventLike};
-    use chrono::{TimeZone as _, Utc};
-    use crate::{Frequency, RRule};
+    use crate::{Event, EventLike as _, Frequency, RRule};
     use chrono::{TimeZone as _, Utc};
 
     /// An event with no RRULE property should return None.

--- a/src/components.rs
+++ b/src/components.rs
@@ -707,4 +707,39 @@ mod tests {
         assert_eq!(event.get_start(), Some(naive_date.into()));
         assert_eq!(event.get_end(), Some(naive_date.into()));
     }
+
+    #[test]
+    fn get_recurrence() {
+        use rrule::{Frequency, NWeekday, RRule, Tz, Weekday};
+
+        let naive_date = NaiveDate::from_ymd_opt(2001, 3, 13).unwrap();
+        let dt_start = Tz::UTC.ymd(2001, 3, 13).and_hms(0, 0, 0);
+
+        let rrule_set = RRule::default()
+            .count(4)
+            .freq(Frequency::Weekly)
+            .by_weekday(vec![
+                NWeekday::Every(Weekday::Tue),
+                NWeekday::Every(Weekday::Wed),
+            ])
+            .build(dt_start)
+            .unwrap();
+
+        let event = Event::new()
+            .starts(naive_date)
+            .ends(naive_date)
+            .recurrence(rrule_set)
+            .done();
+
+        let output = event.get_recurrence().unwrap();
+        let output_rrules = output.get_rrule();
+
+        assert_eq!(output_rrules.len(), 1);
+        assert_eq!(output_rrules[0].get_freq(), Frequency::Weekly);
+        assert_eq!(output_rrules[0].get_interval(), 1);
+        assert_eq!(
+            output_rrules[0].get_by_weekday(),
+            [NWeekday::Every(Weekday::Tue), NWeekday::Every(Weekday::Wed)]
+        );
+    }
 }

--- a/src/components.rs
+++ b/src/components.rs
@@ -449,28 +449,23 @@ pub trait EventLike: Component {
             .collect::<Vec<_>>()
             .join("\n");
 
-        let mut rdates = rruleset
+        let rdates = rruleset
             .get_rdate()
             .iter()
             .map(|dt| dt.format("%Y%m%dT%H%M%SZ").to_string())
             .collect::<Vec<_>>()
             .join(",");
-        if !rdates.is_empty() {
-            rdates = format!("\nRDATE;VALUE=DATE-TIME:{rdates}");
-        }
 
-        let mut exdates = rruleset
+        let exdates = rruleset
             .get_exdate()
             .iter()
             .map(|dt| dt.format("%Y%m%dT%H%M%SZ").to_string())
             .collect::<Vec<_>>()
             .join(",");
-        if !exdates.is_empty() {
-            exdates = format!("\nEXDATE;VALUE=DATE-TIME:{exdates}");
-        }
 
-        let properties = format!("{rrules}{rdates}{exdates}");
-        self.add_property("RRULE", properties)
+        self.add_property("RRULE", rrules)
+            .add_multi_property("RDATE", &rdates)
+            .add_multi_property("EXDATE", &exdates)
     }
 
     /// Get recurrence rules
@@ -478,8 +473,32 @@ pub trait EventLike: Component {
     fn get_recurrence(&self) -> Option<RRuleSet> {
         let dt_start_str = self.property_value("DTSTART")?;
         let rrule_str = self.property_value("RRULE")?;
-        let rrules = format!("DTSTART:{}\nRRULE:{}", dt_start_str, rrule_str);
 
+        let mut rdates_str = self
+            .multi_properties()
+            .get("RDATE")
+            .unwrap_or(&vec![])
+            .iter()
+            .map(|item| item.value())
+            .collect::<Vec<_>>()
+            .join(",");
+        if !rdates_str.is_empty() {
+            rdates_str = format!("\nRDATE:{rdates_str}");
+        }
+
+        let mut exdates_str = self
+            .multi_properties()
+            .get("EXDATE")
+            .unwrap_or(&vec![])
+            .iter()
+            .map(|item| item.value())
+            .collect::<Vec<_>>()
+            .join(",");
+        if !exdates_str.is_empty() {
+            exdates_str = format!("\nEXDATE:{exdates_str}");
+        }
+
+        let rrules = format!("DTSTART:{dt_start_str}\nRRULE:{rrule_str}{rdates_str}{exdates_str}");
         rrules.parse::<RRuleSet>().ok()
     }
 

--- a/src/components.rs
+++ b/src/components.rs
@@ -479,7 +479,7 @@ pub trait EventLike: Component {
             .get("RDATE")
             .unwrap_or(&vec![])
             .iter()
-            .map(|item| item.value())
+            .map(Property::value)
             .collect::<Vec<_>>()
             .join(",");
         if !rdates_str.is_empty() {
@@ -491,7 +491,7 @@ pub trait EventLike: Component {
             .get("EXDATE")
             .unwrap_or(&vec![])
             .iter()
-            .map(|item| item.value())
+            .map(Property::value)
             .collect::<Vec<_>>()
             .join(",");
         if !exdates_str.is_empty() {

--- a/src/components.rs
+++ b/src/components.rs
@@ -1,4 +1,5 @@
 use chrono::{DateTime, NaiveDate, Utc};
+#[cfg(feature = "recurrence")]
 use rrule::RRuleSet;
 use uuid::Uuid;
 
@@ -439,6 +440,7 @@ pub trait EventLike: Component {
     }
 
     /// Set recurrence rules
+    #[cfg(feature = "recurrence")]
     fn recurrence(&mut self, rruleset: RRuleSet) -> &mut Self {
         let rrules = rruleset
             .get_rrule()
@@ -472,6 +474,7 @@ pub trait EventLike: Component {
     }
 
     /// Get recurrence rules
+    #[cfg(feature = "recurrence")]
     fn get_recurrence(&self) -> Option<RRuleSet> {
         let dt_start_str = self.property_value("DTSTART")?;
         let rrule_str = self.property_value("RRULE")?;
@@ -732,8 +735,9 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "recurrence")]
     fn get_recurrence() {
-        use rrule::{Frequency, NWeekday, RRule, Tz, Weekday};
+        use crate::{Frequency, NWeekday, RRule, Tz, Weekday};
 
         let naive_date = NaiveDate::from_ymd_opt(2001, 3, 13).unwrap();
         let dt_start = Tz::UTC.ymd(2001, 3, 13).and_hms(0, 0, 0);

--- a/src/components.rs
+++ b/src/components.rs
@@ -440,13 +440,34 @@ pub trait EventLike: Component {
 
     /// Set recurrence rules
     fn recurrence(&mut self, rruleset: RRuleSet) -> &mut Self {
-        let properties = rruleset
+        let rrules = rruleset
             .get_rrule()
             .iter()
             .map(ToString::to_string)
             .collect::<Vec<_>>()
             .join("\n");
 
+        let mut rdates = rruleset
+            .get_rdate()
+            .iter()
+            .map(|dt| dt.format("%Y%m%dT%H%M%SZ").to_string())
+            .collect::<Vec<_>>()
+            .join(",");
+        if !rdates.is_empty() {
+            rdates = format!("\nRDATE;VALUE=DATE-TIME:{rdates}");
+        }
+
+        let mut exdates = rruleset
+            .get_exdate()
+            .iter()
+            .map(|dt| dt.format("%Y%m%dT%H%M%SZ").to_string())
+            .collect::<Vec<_>>()
+            .join(",");
+        if !exdates.is_empty() {
+            exdates = format!("\nEXDATE;VALUE=DATE-TIME:{exdates}");
+        }
+
+        let properties = format!("{rrules}{rdates}{exdates}");
         self.add_property("RRULE", properties)
     }
 
@@ -455,6 +476,8 @@ pub trait EventLike: Component {
         let dt_start_str = self.property_value("DTSTART")?;
         let rrule_str = self.property_value("RRULE")?;
         let rrules = format!("DTSTART:{}\nRRULE:{}", dt_start_str, rrule_str);
+
+        println!("rrules\n{}", rrules);
 
         rrules.parse::<RRuleSet>().ok()
     }
@@ -723,7 +746,8 @@ mod tests {
                 NWeekday::Every(Weekday::Wed),
             ])
             .build(dt_start)
-            .unwrap();
+            .unwrap()
+            .set_exdates(vec![Tz::UTC.ymd(2001, 3, 14).and_hms(0, 0, 0)]);
 
         let event = Event::new()
             .starts(naive_date)
@@ -732,6 +756,7 @@ mod tests {
             .done();
 
         let output = event.get_recurrence().unwrap();
+
         let output_rrules = output.get_rrule();
 
         assert_eq!(output_rrules.len(), 1);
@@ -740,6 +765,13 @@ mod tests {
         assert_eq!(
             output_rrules.first().unwrap().get_by_weekday(),
             [NWeekday::Every(Weekday::Tue), NWeekday::Every(Weekday::Wed)]
+        );
+
+        let output_exdates = output.get_exdate();
+
+        assert_eq!(
+            output_exdates,
+            &vec![Tz::UTC.ymd(2001, 3, 14).and_hms(0, 0, 0)]
         );
     }
 }

--- a/src/components.rs
+++ b/src/components.rs
@@ -1,6 +1,6 @@
 use chrono::{DateTime, NaiveDate, Utc};
 #[cfg(feature = "recurrence")]
-use rrule::RRuleSet;
+use rrule::{RRuleError, RRuleSet};
 use uuid::Uuid;
 
 use std::{collections::BTreeMap, fmt, mem};
@@ -468,10 +468,20 @@ pub trait EventLike: Component {
             .add_multi_property("EXDATE", &exdates)
     }
 
-    /// Get recurrence rules
+    /// Get recurrence rules.
+    ///
+    /// Returns `None` if no `RRULE` property is present on this component.
+    /// Returns `Some(Err(_))` if an `RRULE` is present but could not be parsed.
     #[cfg(feature = "recurrence")]
-    fn get_recurrence(&self) -> Option<RRuleSet> {
-        let dt_start_str = self.property_value("DTSTART")?;
+    fn get_recurrence(&self) -> Option<Result<RRuleSet, RRuleError>> {
+        let dt_start_prop = self.properties().get("DTSTART")?;
+        // rrule's parser only understands DTSTART with an optional TZID parameter.
+        // Other parameters like VALUE=DATE must be omitted, otherwise rrule misinterprets them.
+        let dt_start_str = if let Some(tzid) = dt_start_prop.params().get("TZID") {
+            format!("DTSTART;TZID={}:{}", tzid.value(), dt_start_prop.value())
+        } else {
+            format!("DTSTART:{}", dt_start_prop.value())
+        };
         let rrule_str = self.property_value("RRULE")?;
 
         let mut rdates_str = self
@@ -498,8 +508,8 @@ pub trait EventLike: Component {
             exdates_str = format!("\nEXDATE:{exdates_str}");
         }
 
-        let rrules = format!("DTSTART:{dt_start_str}\nRRULE:{rrule_str}{rdates_str}{exdates_str}");
-        rrules.parse::<RRuleSet>().ok()
+        let rrules = format!("{dt_start_str}\nRRULE:{rrule_str}{rdates_str}{exdates_str}");
+        Some(rrules.parse::<RRuleSet>())
     }
 
     /// Set the ALARM for this event
@@ -777,7 +787,7 @@ mod tests {
             .recurrence(rrule_set)
             .done();
 
-        let output = event.get_recurrence().unwrap();
+        let output = event.get_recurrence().unwrap().unwrap();
 
         let output_rrules = output.get_rrule();
 
@@ -792,5 +802,196 @@ mod tests {
         let output_exdates = output.get_exdate();
 
         assert_eq!(output_exdates, &vec![ex_date]);
+    }
+}
+
+#[cfg(all(test, feature = "recurrence", feature = "parser"))]
+mod test_recurrence_tzid {
+    use chrono::TimeZone as _;
+    use crate::rrule::{Frequency, RRule, RRuleSet, Tz};
+    use crate::{CalendarComponent, Event, EventLike};
+
+    /// Builds an RRuleSet with a UTC DTSTART and a weekly rule, used across several tests.
+    fn weekly_utc_rrule_set() -> RRuleSet {
+        let dt_start = Tz::UTC.with_ymd_and_hms(2025, 3, 17, 9, 0, 0).unwrap();
+        RRule::default()
+            .count(4)
+            .freq(Frequency::Weekly)
+            .build(dt_start)
+            .unwrap()
+    }
+
+    /// A `DTSTART;TZID=...` event should produce occurrences in the named timezone,
+    /// not in UTC or the local machine timezone.
+    #[test]
+    fn tzid_dtstart_preserves_timezone() {
+        use chrono::NaiveDate;
+        use crate::components::date_time::CalendarDateTime;
+        use crate::rrule::NWeekday;
+        use crate::rrule::Weekday;
+
+        let dt_start_rrule = Tz::Europe__Berlin
+            .with_ymd_and_hms(2025, 6, 2, 10, 0, 0)
+            .unwrap();
+
+        let rrule_set = RRule::default()
+            .count(3)
+            .freq(Frequency::Weekly)
+            .by_weekday(vec![NWeekday::Every(Weekday::Mon)])
+            .build(dt_start_rrule)
+            .unwrap();
+
+        let dt_start_ical = CalendarDateTime::WithTimezone {
+            date_time: NaiveDate::from_ymd_opt(2025, 6, 2)
+                .unwrap()
+                .and_hms_opt(10, 0, 0)
+                .unwrap(),
+            tzid: "Europe/Berlin".to_string(),
+        };
+
+        let event = Event::new()
+            .starts(dt_start_ical)
+            .recurrence(rrule_set)
+            .done();
+
+        let rrule_set_out = event.get_recurrence().unwrap().unwrap();
+        let dates = rrule_set_out.all(10).dates;
+
+        assert_eq!(dates.len(), 3);
+        // All occurrences must be in Europe/Berlin, not UTC
+        for dt in &dates {
+            assert_eq!(dt.timezone(), Tz::Europe__Berlin);
+            assert_eq!(dt.format("%H:%M").to_string(), "10:00");
+        }
+    }
+
+    /// Serializing an event with `DTSTART;TZID=...` and parsing it back must yield the
+    /// same occurrences as the original (round-trip correctness).
+    #[test]
+    fn tzid_dtstart_round_trips_through_serialization() {
+        use chrono::NaiveDate;
+        use crate::components::date_time::CalendarDateTime;
+        use crate::rrule::NWeekday;
+        use crate::rrule::Weekday;
+        use crate::Calendar;
+
+        let dt_start_rrule = Tz::Europe__Berlin
+            .with_ymd_and_hms(2025, 6, 2, 10, 0, 0)
+            .unwrap();
+
+        let rrule_set = RRule::default()
+            .count(3)
+            .freq(Frequency::Weekly)
+            .by_weekday(vec![NWeekday::Every(Weekday::Mon)])
+            .build(dt_start_rrule)
+            .unwrap();
+
+        let dt_start_ical = CalendarDateTime::WithTimezone {
+            date_time: NaiveDate::from_ymd_opt(2025, 6, 2)
+                .unwrap()
+                .and_hms_opt(10, 0, 0)
+                .unwrap(),
+            tzid: "Europe/Berlin".to_string(),
+        };
+
+        let event = Event::new()
+            .starts(dt_start_ical)
+            .recurrence(rrule_set)
+            .done();
+
+        let original_dates = event.get_recurrence().unwrap().unwrap().all(10).dates;
+
+        // Serialize → parse back
+        let mut calendar = Calendar::new();
+        calendar.push(event);
+        let serialized = calendar.to_string();
+        let reparsed: Calendar = serialized.parse().unwrap();
+
+        let reparsed_event = reparsed
+            .components
+            .iter()
+            .find_map(|c| {
+                if let CalendarComponent::Event(e) = c {
+                    Some(e)
+                } else {
+                    None
+                }
+            })
+            .unwrap();
+
+        let reparsed_dates = reparsed_event.get_recurrence().unwrap().unwrap().all(10).dates;
+
+        assert_eq!(original_dates, reparsed_dates);
+        assert_eq!(reparsed_dates.len(), 3);
+    }
+
+    /// A UTC `DTSTART` (no TZID parameter) must still work correctly after the refactor.
+    #[test]
+    fn utc_dtstart_still_works() {
+        use crate::components::date_time::CalendarDateTime;
+        use chrono::{TimeZone, Utc};
+
+        let utc_dt = Utc.with_ymd_and_hms(2025, 3, 17, 9, 0, 0).unwrap();
+
+        let event = Event::new()
+            .starts(CalendarDateTime::Utc(utc_dt))
+            .recurrence(weekly_utc_rrule_set())
+            .done();
+
+        let dates = event.get_recurrence().unwrap().unwrap().all(10).dates;
+        assert_eq!(dates.len(), 4);
+        for dt in &dates {
+            assert_eq!(dt.timezone(), Tz::UTC);
+        }
+    }
+}
+
+#[cfg(all(test, feature = "recurrence"))]
+mod test_recurrence_errors {
+    use crate::rrule::{Frequency, RRule, Tz};
+    use crate::{Event, EventLike};
+    use chrono::{TimeZone as _, Utc};
+    use crate::{Frequency, RRule};
+    use chrono::{TimeZone as _, Utc};
+
+    /// An event with no RRULE property should return None.
+    #[test]
+    fn no_rrule_returns_none() {
+        let event = Event::new()
+            .starts(Utc.with_ymd_and_hms(2025, 1, 1, 9, 0, 0).unwrap())
+            .done();
+
+        assert!(event.get_recurrence().is_none());
+    }
+
+    /// An event with a valid RRULE should return Some(Ok(_)).
+    #[test]
+    fn valid_rrule_returns_some_ok() {
+        let dt_start = Tz::UTC.with_ymd_and_hms(2025, 1, 1, 9, 0, 0).unwrap();
+        let rrule_set = RRule::default()
+            .count(3)
+            .freq(Frequency::Daily)
+            .build(dt_start)
+            .unwrap();
+
+        let event = Event::new()
+            .starts(Utc.with_ymd_and_hms(2025, 1, 1, 9, 0, 0).unwrap())
+            .recurrence(rrule_set)
+            .done();
+
+        assert!(matches!(event.get_recurrence(), Some(Ok(_))));
+    }
+
+    /// An event with a syntactically invalid RRULE value should return Some(Err(_)).
+    #[test]
+    fn invalid_rrule_returns_some_err() {
+        use crate::Component;
+
+        let event = Event::new()
+            .starts(Utc.with_ymd_and_hms(2025, 1, 1, 9, 0, 0).unwrap())
+            .add_property("RRULE", "THIS IS NOT VALID")
+            .done();
+
+        assert!(matches!(event.get_recurrence(), Some(Err(_))));
     }
 }

--- a/src/components.rs
+++ b/src/components.rs
@@ -480,8 +480,6 @@ pub trait EventLike: Component {
         let rrule_str = self.property_value("RRULE")?;
         let rrules = format!("DTSTART:{}\nRRULE:{}", dt_start_str, rrule_str);
 
-        println!("rrules\n{}", rrules);
-
         rrules.parse::<RRuleSet>().ok()
     }
 
@@ -740,7 +738,8 @@ mod tests {
         use crate::rrule::{Frequency, NWeekday, RRule, Tz, Weekday};
 
         let naive_date = NaiveDate::from_ymd_opt(2001, 3, 13).unwrap();
-        let dt_start = Tz::UTC.ymd(2001, 3, 13).and_hms(0, 0, 0);
+        let dt_start = Tz::UTC.with_ymd_and_hms(2001, 3, 13, 0, 0, 0).unwrap();
+        let ex_date = Tz::UTC.with_ymd_and_hms(2001, 3, 14, 0, 0, 0).unwrap();
 
         let rrule_set = RRule::default()
             .count(4)
@@ -751,7 +750,7 @@ mod tests {
             ])
             .build(dt_start)
             .unwrap()
-            .set_exdates(vec![Tz::UTC.ymd(2001, 3, 14).and_hms(0, 0, 0)]);
+            .set_exdates(vec![ex_date]);
 
         let event = Event::new()
             .starts(naive_date)
@@ -773,9 +772,6 @@ mod tests {
 
         let output_exdates = output.get_exdate();
 
-        assert_eq!(
-            output_exdates,
-            &vec![Tz::UTC.ymd(2001, 3, 14).and_hms(0, 0, 0)]
-        );
+        assert_eq!(output_exdates, &vec![ex_date]);
     }
 }

--- a/src/components.rs
+++ b/src/components.rs
@@ -737,7 +737,7 @@ mod tests {
     #[test]
     #[cfg(feature = "recurrence")]
     fn get_recurrence() {
-        use crate::{Frequency, NWeekday, RRule, Tz, Weekday};
+        use crate::rrule::{Frequency, NWeekday, RRule, Tz, Weekday};
 
         let naive_date = NaiveDate::from_ymd_opt(2001, 3, 13).unwrap();
         let dt_start = Tz::UTC.ymd(2001, 3, 13).and_hms(0, 0, 0);

--- a/src/components.rs
+++ b/src/components.rs
@@ -735,10 +735,10 @@ mod tests {
         let output_rrules = output.get_rrule();
 
         assert_eq!(output_rrules.len(), 1);
-        assert_eq!(output_rrules[0].get_freq(), Frequency::Weekly);
-        assert_eq!(output_rrules[0].get_interval(), 1);
+        assert_eq!(output_rrules.first().unwrap().get_freq(), Frequency::Weekly);
+        assert_eq!(output_rrules.first().unwrap().get_interval(), 1);
         assert_eq!(
-            output_rrules[0].get_by_weekday(),
+            output_rrules.first().unwrap().get_by_weekday(),
             [NWeekday::Every(Weekday::Tue), NWeekday::Every(Weekday::Wed)]
         );
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,7 +58,7 @@ pub use crate::{
 };
 
 #[cfg(feature = "recurrence")]
-pub use rrule::{RRuleSet, Frequency, NWeekday, RRule, Tz, Weekday};
+pub use rrule;
 
 #[cfg(feature = "chrono-tz")]
 pub use crate::components::date_time::ymd_hm_tzid;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,6 +57,9 @@ pub use crate::{
     value_types::ValueType,
 };
 
+#[cfg(feature = "recurrence")]
+pub use rrule::{RRuleSet, Frequency, NWeekday, RRule, Tz, Weekday};
+
 #[cfg(feature = "chrono-tz")]
 pub use crate::components::date_time::ymd_hm_tzid;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,7 +58,19 @@ pub use crate::{
 };
 
 #[cfg(feature = "recurrence")]
-pub use rrule::{Frequency, NWeekday, RRule, RRuleError, RRuleSet, Tz, Unvalidated, Weekday};
+pub use rrule::{Frequency, NWeekday, RRule, RRuleError, RRuleSet, Tz, Weekday};
+
+#[cfg(feature = "recurrence")]
+use rrule::Unvalidated;
+
+/// A not-yet-validated recurrence rule. Alias for [`RRule<Unvalidated>`].
+///
+/// Use this type when storing or returning an [`RRule`] that has not yet been
+/// bound to a start date, for example in helper functions or struct fields.
+/// At the call site of [`EventLike::recurrence`] the type is always inferred,
+/// so you only need to name it explicitly when the compiler asks you to.
+#[cfg(feature = "recurrence")]
+pub type UnvalidatedRRule = RRule<Unvalidated>;
 
 #[cfg(feature = "chrono-tz")]
 pub use crate::components::date_time::ymd_hm_tzid;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,6 +44,8 @@ mod components;
 #[cfg(feature = "parser")]
 pub mod parser;
 mod properties;
+#[cfg(feature = "recurrence")]
+mod recurrence;
 mod value_types;
 
 pub use crate::{
@@ -58,7 +60,10 @@ pub use crate::{
 };
 
 #[cfg(feature = "recurrence")]
-pub use rrule::{Frequency, NWeekday, RRule, RRuleError, RRuleSet, Tz, Weekday};
+pub use rrule::{Frequency, NWeekday, RRule, RRuleSet, Tz, Weekday};
+
+#[cfg(feature = "recurrence")]
+pub use crate::recurrence::RecurrenceError;
 
 #[cfg(feature = "recurrence")]
 use rrule::Unvalidated;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,7 +58,7 @@ pub use crate::{
 };
 
 #[cfg(feature = "recurrence")]
-pub use rrule;
+pub use rrule::{Frequency, NWeekday, RRule, RRuleError, RRuleSet, Tz, Unvalidated, Weekday};
 
 #[cfg(feature = "chrono-tz")]
 pub use crate::components::date_time::ymd_hm_tzid;

--- a/src/recurrence.rs
+++ b/src/recurrence.rs
@@ -1,0 +1,33 @@
+//! Error types for recurrence rule handling.
+
+/// Errors that can occur when setting or parsing recurrence rules.
+///
+/// Returned by [`EventLike::recurrence`](crate::EventLike::recurrence) and
+/// [`EventLike::try_recurrence`](crate::EventLike::try_recurrence).
+#[cfg(feature = "recurrence")]
+#[derive(Debug, PartialEq, thiserror::Error)]
+pub enum RecurrenceError {
+    /// `DTSTART` was not set on the component before calling
+    /// [`recurrence()`](crate::EventLike::recurrence). Call `.starts()` or
+    /// `.all_day()` first.
+    #[error("DTSTART must be set before calling recurrence()")]
+    MissingDtStart,
+
+    /// The `TZID` parameter on `DTSTART` could not be resolved to a known
+    /// timezone.
+    #[error("unrecognised timezone in DTSTART: {0}")]
+    InvalidTimezone(String),
+
+    /// The local datetime in `DTSTART` is ambiguous or invalid for the given
+    /// timezone (e.g. a time that falls in a DST gap).
+    #[error("the local datetime in DTSTART is ambiguous or invalid for its timezone")]
+    AmbiguousDateTime,
+
+    /// The `DTSTART` property value could not be parsed.
+    #[error("could not parse DTSTART property value")]
+    InvalidDtStart,
+
+    /// The recurrence rule itself failed rrule's own validation or parsing.
+    #[error("recurrence rule error: {0}")]
+    Rule(#[from] rrule::RRuleError),
+}

--- a/tests/parse_recurrence.rs
+++ b/tests/parse_recurrence.rs
@@ -1,0 +1,46 @@
+#![cfg(feature = "recurrence")]
+use chrono::{DateTime, TimeZone};
+use icalendar::{rrule::Tz, Calendar, CalendarComponent, EventLike};
+
+const TEST_CALENDAR_STR: &str = r#"
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:bsprodidfortestabc123
+BEGIN:VEVENT
+DTSTAMP:20050118T211523Z
+UID:bsuidfortestabc123
+DTSTART;VALUE=DATE:20250101
+DTEND;VALUE=DATE:20250101
+RDATE;VALUE=DATE:20241231,20241230
+SUMMARY:Test Recurrence
+EXDATE;VALUE=DATE:20250102,20250103
+RRULE:FREQ=DAILY;COUNT=4
+END:VEVENT
+END:VCALENDAR
+"#;
+
+#[test]
+fn parse_recurrence() {
+    // calendar string excludes 2nd and 3rd as EXDATE, but includes 30th and 31st as RDATE
+    let expected_datetimes = vec![
+        Tz::UTC.with_ymd_and_hms(2024, 12, 30, 0, 0, 0).unwrap(),
+        Tz::UTC.with_ymd_and_hms(2024, 12, 31, 0, 0, 0).unwrap(),
+        Tz::UTC.with_ymd_and_hms(2025, 1, 1, 0, 0, 0).unwrap(),
+        Tz::UTC.with_ymd_and_hms(2025, 1, 4, 0, 0, 0).unwrap(),
+    ];
+
+    let calendar: Calendar = TEST_CALENDAR_STR.parse().expect("failed to parse calendar");
+    assert_eq!(calendar.components.len(), 1);
+
+    let event = match calendar.components.first() {
+        Some(CalendarComponent::Event(event)) => event,
+        _ => panic!("calendar component should be an event"),
+    };
+
+    let rrules = event
+        .get_recurrence()
+        .expect("event should have recurrence rules");
+    let datetimes: Vec<DateTime<Tz>> = rrules.all(10).dates;
+
+    assert_eq!(datetimes, expected_datetimes);
+}

--- a/tests/parse_recurrence.rs
+++ b/tests/parse_recurrence.rs
@@ -16,31 +16,59 @@ SUMMARY:Test Recurrence
 EXDATE;VALUE=DATE:20250102,20250103
 RRULE:FREQ=DAILY;COUNT=4
 END:VEVENT
+BEGIN:VEVENT
+DTSTAMP:20050118T211523Z
+UID:bsuidfortestabc123
+DTSTART:20250101T090000Z
+DTEND:20250101T110000Z
+RDATE:20241231T100000Z
+SUMMARY:Test Recurrence
+EXDATE:20250102T090000Z,20250103T100000Z
+RRULE:FREQ=DAILY;COUNT=4
+END:VEVENT
 END:VCALENDAR
 "#;
 
 #[test]
 fn parse_recurrence() {
-    // calendar string excludes 2nd and 3rd as EXDATE, but includes 30th and 31st as RDATE
-    let expected_datetimes = vec![
+    // tests recurrence handling for all-day events (dates) and datetimes
+
+    // all-day: calendar string excludes 2nd and 3rd as EXDATE, but includes 30th and 31st as RDATE
+    let expected_datetimes_a = vec![
         Tz::UTC.with_ymd_and_hms(2024, 12, 30, 0, 0, 0).unwrap(),
         Tz::UTC.with_ymd_and_hms(2024, 12, 31, 0, 0, 0).unwrap(),
         Tz::UTC.with_ymd_and_hms(2025, 1, 1, 0, 0, 0).unwrap(),
         Tz::UTC.with_ymd_and_hms(2025, 1, 4, 0, 0, 0).unwrap(),
     ];
 
+    // time-based: calendar string excludes 2nd as EXDATE and does NOT exclude 3rd, and includes 31st as RDATE
+    let expected_datetimes_b = vec![
+        Tz::UTC.with_ymd_and_hms(2024, 12, 31, 10, 0, 0).unwrap(),
+        Tz::UTC.with_ymd_and_hms(2025, 1, 1, 9, 0, 0).unwrap(),
+        Tz::UTC.with_ymd_and_hms(2025, 1, 3, 9, 0, 0).unwrap(),
+        Tz::UTC.with_ymd_and_hms(2025, 1, 4, 9, 0, 0).unwrap(),
+    ];
+
     let calendar: Calendar = TEST_CALENDAR_STR.parse().expect("failed to parse calendar");
-    assert_eq!(calendar.components.len(), 1);
+    assert_eq!(calendar.components.len(), 2);
 
     let event = match calendar.components.first() {
         Some(CalendarComponent::Event(event)) => event,
         _ => panic!("calendar component should be an event"),
     };
-
     let rrules = event
         .get_recurrence()
         .expect("event should have recurrence rules");
     let datetimes: Vec<DateTime<Tz>> = rrules.all(10).dates;
+    assert_eq!(datetimes, expected_datetimes_a);
 
-    assert_eq!(datetimes, expected_datetimes);
+    let event = match calendar.components.get(1) {
+        Some(CalendarComponent::Event(event)) => event,
+        _ => panic!("calendar component should be an event"),
+    };
+    let rrules = event
+        .get_recurrence()
+        .expect("event should have recurrence rules");
+    let datetimes: Vec<DateTime<Tz>> = rrules.all(10).dates;
+    assert_eq!(datetimes, expected_datetimes_b);
 }

--- a/tests/parse_recurrence.rs
+++ b/tests/parse_recurrence.rs
@@ -1,4 +1,4 @@
-#![cfg(feature = "recurrence")]
+#![cfg(all(feature = "recurrence", feature = "parser"))]
 use chrono::{DateTime, TimeZone};
 use icalendar::{Calendar, CalendarComponent, EventLike, Tz};
 

--- a/tests/parse_recurrence.rs
+++ b/tests/parse_recurrence.rs
@@ -1,6 +1,6 @@
 #![cfg(feature = "recurrence")]
 use chrono::{DateTime, TimeZone};
-use icalendar::{rrule::Tz, Calendar, CalendarComponent, EventLike};
+use icalendar::{Calendar, CalendarComponent, EventLike, rrule::Tz};
 
 fn naive_dates(dates: &[DateTime<Tz>]) -> Vec<String> {
     dates

--- a/tests/parse_recurrence.rs
+++ b/tests/parse_recurrence.rs
@@ -1,6 +1,6 @@
 #![cfg(feature = "recurrence")]
 use chrono::{DateTime, TimeZone};
-use icalendar::{Calendar, CalendarComponent, EventLike, rrule::Tz};
+use icalendar::{Calendar, CalendarComponent, EventLike, Tz};
 
 fn naive_dates(dates: &[DateTime<Tz>]) -> Vec<String> {
     dates

--- a/tests/parse_recurrence.rs
+++ b/tests/parse_recurrence.rs
@@ -66,8 +66,7 @@ fn parse_recurrence() {
     };
     let rrules = event
         .get_recurrence()
-        .expect("event should have recurrence rules")
-        .expect("recurrence rules should parse successfully");
+        .expect("event should have recurrence rules");
     let datetimes: Vec<DateTime<Tz>> = rrules.all(10).dates;
     assert_eq!(naive_dates(&datetimes), expected_naive_dates_a);
 
@@ -77,8 +76,7 @@ fn parse_recurrence() {
     };
     let rrules = event
         .get_recurrence()
-        .expect("event should have recurrence rules")
-        .expect("recurrence rules should parse successfully");
+        .expect("event should have recurrence rules");
     let datetimes: Vec<DateTime<Tz>> = rrules.all(10).dates;
     assert_eq!(datetimes, expected_datetimes_b);
 }

--- a/tests/parse_recurrence.rs
+++ b/tests/parse_recurrence.rs
@@ -2,6 +2,13 @@
 use chrono::{DateTime, TimeZone};
 use icalendar::{rrule::Tz, Calendar, CalendarComponent, EventLike};
 
+fn naive_dates(dates: &[DateTime<Tz>]) -> Vec<String> {
+    dates
+        .iter()
+        .map(|dt| dt.naive_local().format("%Y-%m-%dT%H:%M:%S").to_string())
+        .collect()
+}
+
 const TEST_CALENDAR_STR: &str = r#"
 BEGIN:VCALENDAR
 VERSION:2.0
@@ -34,11 +41,12 @@ fn parse_recurrence() {
     // tests recurrence handling for all-day events (dates) and datetimes
 
     // all-day: calendar string excludes 2nd and 3rd as EXDATE, but includes 30th and 31st as RDATE
-    let expected_datetimes_a = vec![
-        Tz::UTC.with_ymd_and_hms(2024, 12, 30, 0, 0, 0).unwrap(),
-        Tz::UTC.with_ymd_and_hms(2024, 12, 31, 0, 0, 0).unwrap(),
-        Tz::UTC.with_ymd_and_hms(2025, 1, 1, 0, 0, 0).unwrap(),
-        Tz::UTC.with_ymd_and_hms(2025, 1, 4, 0, 0, 0).unwrap(),
+    // Bare DATE-only DTSTART has no TZID, so rrule treats it as local/floating — compare naive dates only.
+    let expected_naive_dates_a = vec![
+        "2024-12-30T00:00:00",
+        "2024-12-31T00:00:00",
+        "2025-01-01T00:00:00",
+        "2025-01-04T00:00:00",
     ];
 
     // time-based: calendar string excludes 2nd as EXDATE and does NOT exclude 3rd, and includes 31st as RDATE
@@ -58,9 +66,10 @@ fn parse_recurrence() {
     };
     let rrules = event
         .get_recurrence()
-        .expect("event should have recurrence rules");
+        .expect("event should have recurrence rules")
+        .expect("recurrence rules should parse successfully");
     let datetimes: Vec<DateTime<Tz>> = rrules.all(10).dates;
-    assert_eq!(datetimes, expected_datetimes_a);
+    assert_eq!(naive_dates(&datetimes), expected_naive_dates_a);
 
     let event = match calendar.components.get(1) {
         Some(CalendarComponent::Event(event)) => event,
@@ -68,7 +77,8 @@ fn parse_recurrence() {
     };
     let rrules = event
         .get_recurrence()
-        .expect("event should have recurrence rules");
+        .expect("event should have recurrence rules")
+        .expect("recurrence rules should parse successfully");
     let datetimes: Vec<DateTime<Tz>> = rrules.all(10).dates;
     assert_eq!(datetimes, expected_datetimes_b);
 }


### PR DESCRIPTION
Adds support of adding and fetching recurrence with [rrule](https://github.com/fmeringdal/rust-rrule), which follows `RFC-5545`. Tests are added as well.

Note: Presumably `src/period.rs` and `src/repeats.rs` can be removed if this is a satisfactory implementation.