### PR TITLE
feat: implement std::iter::Extend for Calendar

### DIFF
--- a/src/calendar.rs
+++ b/src/calendar.rs
@@ -81,6 +81,19 @@ impl Default for Calendar {
     }
 }
 
+impl<U> Extend<U> for Calendar
+where
+    U: Into<CalendarComponent>,
+{
+    /// Extends this `Calendar` with the contends of another.
+    fn extend<T>(&mut self, other: T)
+    where
+        T: IntoIterator<Item = U>,
+    {
+        self.extend(other.into_iter().map(Into::into));
+    }
+}
+
 impl Calendar {
     /// Creates a new Calendar.
     pub fn new() -> Self {


### PR DESCRIPTION
This could be considered a breaking change, although the functionality stays the same, since users are now required to have the `std::iter::Extend` trait available and in scope.

Let me know what you think, and I'll add the `!` if necessary
