### PR TITLE
docs: remove done

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,16 +44,13 @@ let my_calendar = Calendar::new()
                 Property::new("TEST", "FOOBAR")
                     .add_parameter("IMPORTANCE", "very")
                     .add_parameter("DUE", "tomorrow")
-                    .done(),
             )
-            .done(),
     )
     .push(
         // add a todo
         Todo::new()
             .summary("groceries")
             .description("Buy some milk")
-            .done(),
     )
     .push(
         // add an all-day event
@@ -61,7 +58,6 @@ let my_calendar = Calendar::new()
             .all_day(NaiveDate::from_ymd_opt(2016, 3, 15).unwrap())
             .summary("My Birthday")
             .description("Hey, I'm gonna have a party\nBYOB: Bring your own beer.\nHendrik")
-            .done(),
     )
     .push(
         // event with utc timezone
@@ -73,7 +69,6 @@ let my_calendar = Calendar::new()
             ))
             .summary("Birthday Party")
             .description("I'm gonna have a party\nBYOB: Bring your own beer.\nHendrik")
-            .done(),
     )
     .done();
 
@@ -90,22 +85,22 @@ use icalendar::{Calendar, Component, Event, EventStatus, Todo, TodoStatus};
 use chrono::Utc;
 
 // Create a completed todo
-let mut todo = Todo::new()
+let mut todo = Todo::new();
+todo
     .summary("Buy milk")
     .completed(Utc::now())
     .percent_complete(100)
-    .status(TodoStatus::Completed)
-    .done();
+    .status(TodoStatus::Completed);
 
 // Later, mark it as uncompleted by removing completion properties
 todo.mark_uncompleted();
 // This removes COMPLETED, PERCENT-COMPLETE, and STATUS properties
 
 // For events, you can remove specific properties
-let mut event = Event::new()
+let mut event = Event::new();
+event
     .summary("Team Meeting")
-    .status(EventStatus::Cancelled)
-    .done();
+    .status(EventStatus::Cancelled);
 
 // Remove the cancelled status
 event.remove_status();


### PR DESCRIPTION
This PR removes the `done` calls from the README examples, which were missed in the previous PR.

BTW, I noticed that `done` is still used in many places throughout the codebase. Should we consider cleaning them up, or even marking `done` as deprecated?

Follow up: #148

<!--
First and foremost, thank you for taking the time to contribute to this project! Your efforts are greatly appreciated.

## Semantic Commit Messages
Please ensure your commit messages follows the [Conventional Commits Specification](https://www.conventionalcommits.org/en/v1.0.0/),
as these are being used to automatically generate the changelog and determine the version bump for releases.

Most importantly: [Mark breaking changes accordingly](https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer)!

### Example
```
feat: add new user authentication module

fix: resolve issue with user not being able to login

feat!: remove deprecated user module
```
->>


Again, thank you for your contribution!
If you have any questions or need assistance, don't hesitate to ask. We're here to help!
