### PR TITLE
feat: add remove_xxx method for optional propeties

### DIFF
--- a/src/components.rs
+++ b/src/components.rs
@@ -173,6 +173,11 @@ pub trait Component {
         self.add_property("DTSTAMP", format_utc_date_time(dt))
     }
 
+    /// Remove the [`DTSTAMP`](https://datatracker.ietf.org/doc/html/rfc5545#section-3.8.7.2) [`Property`]
+    fn remove_timestamp(&mut self) -> &mut Self {
+        self.remove_property("DTSTAMP")
+    }
+
     /// Gets the [`DTSTAMP`](https://datatracker.ietf.org/doc/html/rfc5545#section-3.8.7.2) property.
     fn get_timestamp(&self) -> Option<DateTime<Utc>> {
         parse_utc_date_time(self.property_value("DTSTAMP")?)
@@ -199,6 +204,11 @@ pub trait Component {
     fn priority(&mut self, priority: u32) -> &mut Self {
         let priority = std::cmp::min(priority, 10);
         self.add_property("PRIORITY", priority.to_string())
+    }
+
+    /// Removes the relative priority.
+    fn remove_priority(&mut self) -> &mut Self {
+        self.remove_property("PRIORITY")
     }
 
     // /// Add the [`ATTACH`](https://datatracker.ietf.org/doc/html/rfc5545#section-3.8.1.1) property
@@ -233,6 +243,11 @@ pub trait Component {
         self.add_property("SUMMARY", desc)
     }
 
+    /// Removes the summary
+    fn remove_summary(&mut self) -> &mut Self {
+        self.remove_property("SUMMARY")
+    }
+
     /// Gets the summary
     fn get_summary(&self) -> Option<&str> {
         self.property_value("SUMMARY")
@@ -241,6 +256,11 @@ pub trait Component {
     /// Set the description
     fn description(&mut self, desc: &str) -> &mut Self {
         self.add_property("DESCRIPTION", desc)
+    }
+
+    /// Removes the description
+    fn remove_description(&mut self) -> &mut Self {
+        self.remove_property("DESCRIPTION")
     }
 
     /// Gets the description
@@ -269,7 +289,12 @@ pub trait Component {
         self.add_property("SEQUENCE", sequence.to_string())
     }
 
-    /// Gets the SEQUENCE
+    /// Removes the sequence
+    fn remove_sequence(&mut self) -> &mut Self {
+        self.remove_property("SEQUENCE")
+    }
+
+    /// Gets the sequence
     fn get_sequence(&self) -> Option<u32> {
         self.property_value("SEQUENCE").and_then(|s| s.parse().ok())
     }
@@ -277,6 +302,11 @@ pub trait Component {
     /// Set the visibility class
     fn class(&mut self, class: Class) -> &mut Self {
         self.append_property(class)
+    }
+
+    /// Removes the visibility class
+    fn remove_class(&mut self) -> &mut Self {
+        self.remove_property("CLASS")
     }
 
     /// Gets the visibility class
@@ -287,6 +317,11 @@ pub trait Component {
     /// Sets the URL.
     fn url(&mut self, url: &str) -> &mut Self {
         self.add_property("URL", url)
+    }
+
+    /// Removes the URL.
+    fn remove_url(&mut self) -> &mut Self {
+        self.remove_property("URL")
     }
 
     /// Gets the URL.
@@ -301,6 +336,11 @@ pub trait Component {
         self.add_property("LAST-MODIFIED", format_utc_date_time(dt))
     }
 
+    /// Removes the [`LAST-MODIFIED`](https://datatracker.ietf.org/doc/html/rfc5545#section-3.8.7.3) [`Property`]
+    fn remove_last_modified(&mut self) -> &mut Self {
+        self.remove_property("LAST-MODIFIED")
+    }
+
     /// Gets the [`LAST-MODIFIED`](https://datatracker.ietf.org/doc/html/rfc5545#section-3.8.7.3) property.
     fn get_last_modified(&self) -> Option<DateTime<Utc>> {
         parse_utc_date_time(self.property_value("LAST-MODIFIED")?)
@@ -311,6 +351,11 @@ pub trait Component {
     /// This must be a UTC date-time value.
     fn created(&mut self, dt: DateTime<Utc>) -> &mut Self {
         self.add_property("CREATED", format_utc_date_time(dt))
+    }
+
+    /// Removes the [`CREATED`](https://datatracker.ietf.org/doc/html/rfc5545#section-3.8.7.1) [`Property`]
+    fn remove_created(&mut self) -> &mut Self {
+        self.remove_property("CREATED")
     }
 
     /// Gets the [`CREATED`](https://datatracker.ietf.org/doc/html/rfc5545#section-3.8.7.1) property.
@@ -329,12 +374,22 @@ pub trait EventLike: Component {
         self.append_property(calendar_dt.to_property("DTSTART"))
     }
 
+    /// removes the [`DTSTART`](https://datatracker.ietf.org/doc/html/rfc5545#section-3.8.2.4) [`Property`]
+    fn remove_starts(&mut self) -> &mut Self {
+        self.remove_property("DTSTART")
+    }
+
     /// Set the [`DTEND`](https://datatracker.ietf.org/doc/html/rfc5545#section-3.8.2.2) [`Property`]
     ///
     /// See [`DatePerhapsTime`] for info how are different [`chrono`] types converted automatically.
     fn ends<T: Into<DatePerhapsTime>>(&mut self, dt: T) -> &mut Self {
         let calendar_dt = dt.into();
         self.append_property(calendar_dt.to_property("DTEND"))
+    }
+
+    /// Removes the [`DTEND`](https://datatracker.ietf.org/doc/html/rfc5545#section-3.8.2.2) [`Property`]
+    fn remove_ends(&mut self) -> &mut Self {
+        self.remove_property("DTEND")
     }
 
     /// Sets the [`RECURRENCE-ID`](https://datatracker.ietf.org/doc/html/rfc5545#section-3.8.4.4)
@@ -344,6 +399,11 @@ pub trait EventLike: Component {
     fn recurrence_id<T: Into<DatePerhapsTime>>(&mut self, dt: T) -> &mut Self {
         let calendar_dt = dt.into();
         self.append_property(calendar_dt.to_property("RECURRENCE-ID"))
+    }
+
+    /// Removes the [`RECURRENCE-ID`](https://datatracker.ietf.org/doc/html/rfc5545#section-3.8.4.4)
+    fn remove_recurrence_id(&mut self) -> &mut Self {
+        self.remove_property("RECURRENCE-ID")
     }
 
     /// Set the [`DTSTART`](https://datatracker.ietf.org/doc/html/rfc5545#section-3.8.2.4) [`Property`]
@@ -369,6 +429,11 @@ pub trait EventLike: Component {
     /// 3.8.1.7.  Location
     fn location(&mut self, location: &str) -> &mut Self {
         self.add_property("LOCATION", location)
+    }
+
+    /// Removes the LOCATION with a VVENUE UID
+    fn remove_location(&mut self) -> &mut Self {
+        self.remove_property("LOCATION")
     }
 
     /// Gets the location
@@ -531,6 +596,40 @@ mod tests {
         assert_eq!(event.get_uid(), Some("uid"));
         assert_eq!(event.get_class(), Some(Class::Private));
         assert_eq!(event.get_url(), Some("http://some.test/url"));
+    }
+
+    #[test]
+    fn get_properties_remove() {
+        let mut event = Event::new()
+            .priority(5)
+            .summary("summary")
+            .description("description")
+            .location("location")
+            .uid("uid")
+            .class(Class::Private)
+            .url("http://some.test/url")
+            .done();
+        assert_eq!(event.get_priority(), Some(5));
+        assert_eq!(event.get_summary(), Some("summary"));
+        assert_eq!(event.get_description(), Some("description"));
+        assert_eq!(event.get_location(), Some("location"));
+        assert_eq!(event.get_uid(), Some("uid"));
+        assert_eq!(event.get_class(), Some(Class::Private));
+        assert_eq!(event.get_url(), Some("http://some.test/url"));
+
+        event
+            .remove_priority()
+            .remove_summary()
+            .remove_description()
+            .remove_location()
+            .remove_class()
+            .remove_url();
+        assert_eq!(event.get_priority(), None);
+        assert_eq!(event.get_summary(), None);
+        assert_eq!(event.get_description(), None);
+        assert_eq!(event.get_location(), None);
+        assert_eq!(event.get_class(), None);
+        assert_eq!(event.get_url(), None);
     }
 
     #[test]

--- a/src/components/todo.rs
+++ b/src/components/todo.rs
@@ -34,6 +34,11 @@ impl Todo {
         self.add_property("PERCENT-COMPLETE", percent.to_string())
     }
 
+    /// Removes the [`PERCENT-COMPLETE`](https://datatracker.ietf.org/doc/html/rfc5545#section-3.8.1.8) property.
+    pub fn remove_percent_complete(&mut self) -> &mut Self {
+        self.remove_property("PERCENT-COMPLETE")
+    }
+
     /// Gets the [`PERCENT-COMPLETE`](https://datatracker.ietf.org/doc/html/rfc5545#section-3.8.1.8) property.
     ///
     /// Ranges between 0 - 100.
@@ -49,6 +54,11 @@ impl Todo {
         self.append_property(calendar_dt.to_property("DUE"))
     }
 
+    /// Removes the [`DUE`](https://datatracker.ietf.org/doc/html/rfc5545#section-3.8.2.3) property
+    pub fn remove_due(&mut self) -> &mut Self {
+        self.remove_property("DUE")
+    }
+
     /// Gets the [`DUE`](https://datatracker.ietf.org/doc/html/rfc5545#section-3.8.2.3) property
     pub fn get_due(&self) -> Option<DatePerhapsTime> {
         DatePerhapsTime::from_property(self.properties().get("DUE")?)
@@ -60,6 +70,11 @@ impl Todo {
     /// must be a date-time in UTC format.
     pub fn completed(&mut self, dt: DateTime<Utc>) -> &mut Self {
         self.add_property("COMPLETED", format_utc_date_time(dt))
+    }
+
+    /// Removes the [`COMPLETED`](https://datatracker.ietf.org/doc/html/rfc5545#section-3.8.2.1) property
+    pub fn remove_completed(&mut self) -> &mut Self {
+        self.remove_property("COMPLETED")
     }
 
     /// Gets the [`COMPLETED`](https://datatracker.ietf.org/doc/html/rfc5545#section-3.8.2.1) property
@@ -74,6 +89,11 @@ impl Todo {
     /// Defines the overall status or confirmation
     pub fn status(&mut self, status: TodoStatus) -> &mut Self {
         self.append_property(status)
+    }
+
+    /// Removes the overall status
+    pub fn remove_status(&mut self) -> &mut Self {
+        self.remove_property("STATUS")
     }
 
     /// Gets the overall status.
@@ -143,6 +163,26 @@ mod tests {
         assert_eq!(todo.get_percent_complete(), Some(42));
         assert_eq!(todo.get_status(), Some(TodoStatus::NeedsAction));
         assert_eq!(todo.get_completed(), Some(completed))
+    }
+
+    #[test]
+    fn get_properties_remove() {
+        let completed = Utc.with_ymd_and_hms(2001, 3, 13, 14, 15, 16).unwrap();
+        let mut todo = Todo::new()
+            .percent_complete(42)
+            .status(TodoStatus::NeedsAction)
+            .completed(completed)
+            .done();
+        assert_eq!(todo.get_percent_complete(), Some(42));
+        assert_eq!(todo.get_status(), Some(TodoStatus::NeedsAction));
+        assert_eq!(todo.get_completed(), Some(completed));
+
+        todo.remove_percent_complete()
+            .remove_status()
+            .remove_completed();
+        assert_eq!(todo.get_percent_complete(), None);
+        assert_eq!(todo.get_status(), None);
+        assert_eq!(todo.get_completed(), None);
     }
 
     #[test]

--- a/src/components/venue.rs
+++ b/src/components/venue.rs
@@ -32,6 +32,11 @@ impl Venue {
         self.add_property("STREET-ADDRESS", address)
     }
 
+    /// Removes the value of the STREET-ADDRESS `Property`.
+    pub fn remove_street_address(&mut self) -> &mut Self {
+        self.remove_property("STREET-ADDRESS")
+    }
+
     /// Gets the value of the STREET-ADDRESS `Property`.
     pub fn get_street_address(&self) -> Option<&str> {
         self.property_value("STREET-ADDRESS")
@@ -47,6 +52,11 @@ impl Venue {
         self.add_property("EXTENDED-ADDRESS", address)
     }
 
+    /// Removes the EXTENDED-ADDRESS `Property`
+    pub fn remove_extended_address(&mut self) -> &mut Self {
+        self.remove_property("EXTENDED-ADDRESS")
+    }
+
     /// Gets the value of the EXTENDED-ADDRESS `Property`.
     pub fn get_extended_address(&self) -> Option<&str> {
         self.property_value("EXTENDED-ADDRESS")
@@ -57,6 +67,11 @@ impl Venue {
     /// This specifies the city or locality of a venue.
     pub fn locality(&mut self, locality: &str) -> &mut Self {
         self.add_property("LOCALITY", locality)
+    }
+
+    /// Removes the LOCALITY `Property`
+    pub fn remove_locality(&mut self) -> &mut Self {
+        self.remove_property("LOCALITY")
     }
 
     /// Gets the value of the LOCALITY `Property`.
@@ -71,6 +86,11 @@ impl Venue {
         self.add_property("REGION", region)
     }
 
+    /// Removes the REGION `Property`
+    pub fn remove_region(&mut self) -> &mut Self {
+        self.remove_property("REGION")
+    }
+
     /// Gets the value of the REGION `Property`.
     pub fn get_region(&self) -> Option<&str> {
         self.property_value("REGION")
@@ -83,6 +103,11 @@ impl Venue {
         self.add_property("COUNTRY", country)
     }
 
+    /// Removes the COUNTRY `Property`
+    pub fn remove_country(&mut self) -> &mut Self {
+        self.remove_property("COUNTRY")
+    }
+
     /// Gets the value of the COUNTRY `Property`.
     pub fn get_country(&self) -> Option<&str> {
         self.property_value("COUNTRY")
@@ -93,6 +118,11 @@ impl Venue {
     /// This specifies the postal code of a location.
     pub fn postal_code(&mut self, postal_code: &str) -> &mut Self {
         self.add_property("POSTAL-CODE", postal_code)
+    }
+
+    /// Removes the POSTAL-CODE `Property`
+    pub fn remove_postal_code(&mut self) -> &mut Self {
+        self.remove_property("POSTAL-CODE")
     }
 
     /// Gets the value of the POSTAL-CODE `Property`.
@@ -132,5 +162,37 @@ mod tests {
         assert_eq!(venue.get_region(), Some("region"));
         assert_eq!(venue.get_country(), Some("country"));
         assert_eq!(venue.get_postal_code(), Some("postal code"));
+    }
+
+    #[test]
+    fn get_properties_remove() {
+        let mut venue = Venue::new()
+            .street_address("street address")
+            .extended_address("extended address")
+            .locality("locality")
+            .region("region")
+            .country("country")
+            .postal_code("postal code")
+            .done();
+        assert_eq!(venue.get_street_address(), Some("street address"));
+        assert_eq!(venue.get_extended_address(), Some("extended address"));
+        assert_eq!(venue.get_locality(), Some("locality"));
+        assert_eq!(venue.get_region(), Some("region"));
+        assert_eq!(venue.get_country(), Some("country"));
+        assert_eq!(venue.get_postal_code(), Some("postal code"));
+
+        venue
+            .remove_street_address()
+            .remove_extended_address()
+            .remove_locality()
+            .remove_region()
+            .remove_country()
+            .remove_postal_code();
+        assert_eq!(venue.get_street_address(), None);
+        assert_eq!(venue.get_extended_address(), None);
+        assert_eq!(venue.get_locality(), None);
+        assert_eq!(venue.get_region(), None);
+        assert_eq!(venue.get_country(), None);
+        assert_eq!(venue.get_postal_code(), None);
     }
 }


### PR DESCRIPTION
This PR adds multiple `remove_xxx` methods for properties that have corresponding `xxx()` setters or `get_xxx()` getters (excluding `uid`, which is required), along with related tests.

Also, thanks for the great work!

Follow up: #141

<!--
First and foremost, thank you for taking the time to contribute to this project! Your efforts are greatly appreciated.

## Semantic Commit Messages
Please ensure your commit messages follows the [Conventional Commits Specification](https://www.conventionalcommits.org/en/v1.0.0/),
as these are being used to automatically generate the changelog and determine the version bump for releases.

Most importantly: [Mark breaking changes accordingly](https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer)!

### Example
```
feat: add new user authentication module

fix: resolve issue with user not being able to login

feat!: remove deprecated user module
```
->>


Again, thank you for your contribution!
If you have any questions or need assistance, don't hesitate to ask. We're here to help!
