### PR TITLE
fix: Prevent invalid text from being parsed as empty calendars

### DIFF
--- a/src/parser/components.rs
+++ b/src/parser/components.rs
@@ -6,7 +6,7 @@ use nom::{
     bytes::complete::tag,
     combinator::{all_consuming, complete, cut},
     error::{context, ContextError, ParseError},
-    multi::{many0, many_till},
+    multi::{many0, many1, many_till},
     Finish, IResult, Parser,
 };
 
@@ -520,5 +520,17 @@ pub fn components<'i, E>(input: &'i str) -> IResult<&'i str, Vec<Component<'i>>,
 where
     E: ParseError<&'i str> + ContextError<&'i str>,
 {
-    complete(many0(all_consuming(component))).parse(input)
+    complete(many1(all_consuming(component))).parse(input)
+}
+
+#[test]
+fn test_empty_string() {
+    let result = component::<VerboseError<&str>>("");
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_arbitrary_string() {
+    let result = component::<VerboseError<&str>>("This is not a component");
+    assert!(result.is_err());
 }


### PR DESCRIPTION
Currently arbitrary strings are being parsed as valid (albeit empty) Calendars, it is surprising to find that something like "The quick brown fox" can be parsed as an empty calendar.