### PR TITLE
fix: use BTreeMap in properties, so they'll be serialized deterministically

### DIFF
--- a/src/components/alarm.rs
+++ b/src/components/alarm.rs
@@ -1,5 +1,5 @@
 use chrono::Duration;
-use std::{collections::HashMap, fmt::Debug, str::FromStr};
+use std::{fmt::Debug, str::FromStr};
 
 pub use self::properties::{Related, Trigger};
 
@@ -332,7 +332,7 @@ pub mod properties {
             Property {
                 key: String::from("ACTION"),
                 val: action.to_string(),
-                params: HashMap::new(),
+                params: Default::default(),
             }
         }
     }

--- a/src/properties.rs
+++ b/src/properties.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::HashMap,
+    collections::BTreeMap,
     fmt::{self, Write},
     mem,
     str::FromStr,
@@ -40,8 +40,7 @@ impl From<(&str, &str)> for Parameter {
     }
 }
 
-//type EntryParameters = Vec<Parameter>;
-pub type EntryParameters = HashMap<String, Parameter>;
+pub type EntryParameters = BTreeMap<String, Parameter>;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 /// key-value pairs inside of `Component`s
@@ -69,7 +68,7 @@ impl Property {
         Property {
             key: key.into(),
             val: val.into(),
-            params: HashMap::new(),
+            params: Default::default(),
         }
     }
 
@@ -79,7 +78,7 @@ impl Property {
         Property {
             key,
             val,
-            params: HashMap::new(),
+            params: Default::default(),
         }
     }
 
@@ -241,7 +240,7 @@ impl From<Class> for Property {
                 Class::Private => "PRIVATE",
                 Class::Confidential => "CONFIDENTIAL",
             }),
-            params: HashMap::new(),
+            params: Default::default(),
         }
     }
 }
@@ -313,7 +312,7 @@ impl From<EventStatus> for Property {
                 EventStatus::Confirmed => "CONFIRMED",
                 EventStatus::Cancelled => "CANCELLED",
             }),
-            params: HashMap::new(),
+            params: Default::default(),
         }
     }
 }


### PR DESCRIPTION
This is just like issue #7, and I applied the same fix.

I also replaced `HashMap::new()` with `Default::default()` which I think does the same thing but doesn't require you to name the type, so it's more future-proof.

`cargo test` and `cargo clippy` passed locally. This crate has been instrumental for my calendar project, so thank you for maintaining it!