### PR TITLE
Expose `Other` component

### DIFF
--- a/src/calendar/calendar_component.rs
+++ b/src/calendar/calendar_component.rs
@@ -11,7 +11,6 @@ pub enum CalendarComponent {
     Todo(Todo),
     Event(Event),
     Venue(Venue),
-    #[doc(hidden)]
     Other(Other),
 }
 

--- a/src/components/other.rs
+++ b/src/components/other.rs
@@ -1,5 +1,6 @@
 use super::*;
 
+/// A general catch-all component.
 #[derive(Debug, Default, PartialEq, Eq, Clone)]
 pub struct Other {
     name: String,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,7 +51,7 @@ pub use crate::{
     components::{
         alarm::{Alarm, Related, Trigger},
         date_time::{CalendarDateTime, DatePerhapsTime},
-        Component, Event, EventLike, Todo, Venue,
+        Component, Event, EventLike, Other, Todo, Venue,
     },
     properties::{Class, EventStatus, Parameter, Property, TodoStatus},
     value_types::ValueType,


### PR DESCRIPTION
This allows others to implement the `Component` trait for components not currently covered, or custom wrapper types.

<!--
First and foremost, thank you for taking the time to contribute to this project! Your efforts are greatly appreciated.

## Semantic Commit Messages
Please ensure your commit messages follows the [Conventional Commits Specification](https://www.conventionalcommits.org/en/v1.0.0/),
as these are being used to automatically generate the changelog and determine the version bump for releases.

Most importantly: [Mark breaking changes accordingly](https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-description-and-breaking-change-footer)!

### Example
```
feat: add new user authentication module

fix: resolve issue with user not being able to login

feat!: remove deprecated user module
```
->>


Again, thank you for your contribution!
If you have any questions or need assistance, don't hesitate to ask. We're here to help!
