### PR TITLE
fix: X-WR-CALDESC property non properly escaped

### DIFF
--- a/src/value_types.rs
+++ b/src/value_types.rs
@@ -93,8 +93,8 @@ impl ValueType {
             "SEQUENCE" => Some(Integer),         // 3.8.7.4
             // 3.8.8.1
             // "An IANA-registered property name" => Any parameter can be specified on this property.
-            // "X-"/* ... */ => Some(Text),       // any type 3.8.8.2
-            "REQUEST-STATUS" => Some(Text), // 3.8.8.3
+            n if n.starts_with("X-") => Some(Text), // any type 3.8.8.2
+            "REQUEST-STATUS" => Some(Text),         // 3.8.8.3
             _ => None,
         }
     }


### PR DESCRIPTION
Hello,
I'm using your crate to generate a ICS calendar file for a little project of mine related to creating motorsport calendars.

I discovered that by adding a description to the calendar, only the DESCRIPTION: property was correctly escapen when saved to file and instead the X-WR-CALDESC: property was written improperly.

Reading a bit the code I found that the `X-` properties were not treated as Text but also that line was commented so, maybe something you are already working on or there are problems. Anyway, for my use case, this simple modification solves the issue. 

Maybe a more restrictive approach would be to specifically add only `X-WR-CALNAME` and `X-WR-CALDESC` which are directly added in the code of icalendar instead of the generic `.starts_with`


BEFORE:
```
NAME:WorldSBK 2026 full
X-WR-CALNAME:WorldSBK 2026 full
DESCRIPTION:Calendar for the 2026 season of the World Superbike championshi
 p.\n\nFilter applied: full\n\n by nixxo
X-WR-CALDESC:Calendar for the 2026 season of the World Superbike championsh
 ip.

Filter applied: full

 by nixxo
BEGIN:VEVENT
```
```
AFTER:
NAME:WorldSBK 2026 full
X-WR-CALNAME:WorldSBK 2026 full
DESCRIPTION:Calendar for the 2026 season of the World Superbike championshi
 p.\n\nFilter applied: full\n\n by nixxo
X-WR-CALDESC:Calendar for the 2026 season of the World Superbike championsh
 ip.\n\nFilter applied: full\n\n by nixxo
BEGIN:VEVENT
```
